### PR TITLE
WIP [BE-11] [BE-12] Notification, UserNotification 도메인 모델링

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/model/notification/Notification.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/Notification.java
@@ -1,0 +1,83 @@
+package im.fooding.core.model.notification;
+
+import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User source;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "destination_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User destination;
+
+    private String sourceEmail;
+
+    private String destinationEmail;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationChannel channel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationStatus status;
+
+    private LocalDateTime sentAt;
+
+    private LocalDateTime readAt;
+
+    private LocalDateTime scheduledAt;
+
+    @Builder
+    public Notification(User source, User destination, String sourceEmail, String destinationEmail,
+                        String title, String content, NotificationChannel channel, NotificationStatus status) {
+      this.source = source;
+      this.destination = destination;
+      this.sourceEmail = sourceEmail;
+      this.destinationEmail = destinationEmail;
+      this.title = title;
+      this.content = content;
+      this.channel = channel;
+      this.status = status;
+    }
+
+    public void markAsSent() {
+      this.sentAt = LocalDateTime.now();
+      this.status = NotificationStatus.COMPLETED;
+    }
+
+    public void markAsRead() {
+      this.readAt = LocalDateTime.now();
+      }
+
+    public void scheduleAt(LocalDateTime scheduledAt) {
+    this.scheduledAt = scheduledAt;
+    this.status = NotificationStatus.PENDING;
+  }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationChannel.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationChannel.java
@@ -1,0 +1,5 @@
+package im.fooding.core.model.notification;
+
+public enum NotificationChannel {
+    SMS, MAIL, PUSH, KAKAO;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationStatus.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationStatus.java
@@ -1,0 +1,5 @@
+package im.fooding.core.model.notification;
+
+public enum NotificationStatus {
+    PENDING, SENDING, COMPLETED, FAILED;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/UserNotification.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/UserNotification.java
@@ -1,0 +1,51 @@
+package im.fooding.core.model.notification;
+
+import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+@Table(name = "user_notification")
+public class UserNotification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    private LocalDateTime readAt;
+
+    @Builder
+    public UserNotification(User user, String title, String content, LocalDateTime sentAt) {
+      this.user = user;
+      this.title = title;
+      this.content = content;
+      this.sentAt = sentAt;
+    }
+
+    public void markAsRead() {
+      this.readAt = LocalDateTime.now();
+  }
+}


### PR DESCRIPTION
BE-11 BE-12

Notification, UserNotification 엔티티 도메인 모델링 피드백 반영하여 작성 완료했습니다.
알림 도메인의 경우 티켓 ID 2개로 나눠져 있었으나 하나의 ID로 1차 PR 올렸습니다.

현재 필드 구성과 메서드 정의가 설계 의도에 맞게 잘 반영되었는지 아리송한 부분이 있습니다.
리뷰 남겨주시면 반영 후 수정하겠습니다. 



