### PR TITLE
[BE-19] 웨이팅 대기열 입장 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/WaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/WaitingController.java
@@ -1,0 +1,33 @@
+package im.fooding.app.controller.waiting;
+
+import im.fooding.app.dto.request.waiting.WaitingRegisterRequest;
+import im.fooding.app.dto.request.waiting.WaitingRegisterServiceRequest;
+import im.fooding.app.dto.response.waiting.WaitingRegisterResponse;
+import im.fooding.app.dto.response.waiting.WaitingRegisterServiceResponse;
+import im.fooding.app.service.waiting.WaitingApplicationService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/waiting")
+@Tag(name = "WaitingController", description = "웨이팅 관리 컨트롤러")
+@Slf4j
+public class WaitingController {
+
+    private final WaitingApplicationService waitingApplicationService;
+
+    @PostMapping
+    @Operation(summary = "웨이팅 등록")
+    ApiResult<WaitingRegisterResponse> register(@RequestBody @Valid WaitingRegisterRequest request) {
+        WaitingRegisterServiceRequest serviceRequest = request.toWaitingRegisterServiceRequest();
+        WaitingRegisterServiceResponse response = waitingApplicationService.register(serviceRequest);
+
+        return ApiResult.ok(WaitingRegisterResponse.from(response));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/WaitingRegisterRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/WaitingRegisterRequest.java
@@ -1,0 +1,67 @@
+package im.fooding.app.dto.request.waiting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record WaitingRegisterRequest(
+        @NotNull
+        @Schema(description = "가게 아이디", example = "1")
+        long storeId,
+
+        @Schema(description = "웨이팅 유저 이름", example = "홍길동")
+        String name,
+
+        @NotBlank
+        @Schema(description = "핸드폰 번호", example = "01012345678")
+        String phoneNumber,
+
+        @NotNull
+        @Schema(description = "서비스 이용약관 동의", example = "true")
+        boolean termsAgreed,
+
+        @NotNull
+        @Schema(description = "개인정보 수집 및 이용 동의", example = "true")
+        boolean privacyPolicyAgreed,
+
+        @NotNull
+        @Schema(description = "개인정보 제3자 제공 동의", example = "true")
+        boolean thirdPartyAgreed,
+
+        @NotNull
+        @Schema(description = "마케팅 정보 수신 동의", example = "true")
+        boolean marketingConsent,
+
+        @NotBlank
+        @Schema(description = "현장 등록(IN_PERSON) or 온라인 등록(ONLINE)", example = "IN_PERSON")
+        String channel,
+
+        @NotNull
+        @Schema(description = "필요한 유아용 의자 개수", example = "1")
+        int infantChairCount,
+
+        @NotNull
+        @Schema(description = "유아 입장 인원수", example = "1")
+        int infantCount,
+
+        @NotNull
+        @Schema(description = "성인 입장 인원수", example = "1")
+        int adultCount
+) {
+
+    public WaitingRegisterServiceRequest toWaitingRegisterServiceRequest() {
+        return WaitingRegisterServiceRequest.builder()
+                .storeId(storeId)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .termsAgreed(termsAgreed)
+                .privacyPolicyAgreed(privacyPolicyAgreed)
+                .thirdPartyAgreed(thirdPartyAgreed)
+                .marketingConsent(marketingConsent)
+                .channel(channel)
+                .infantChairCount(infantChairCount)
+                .infantCount(infantCount)
+                .adultCount(adultCount)
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/WaitingRegisterServiceRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/WaitingRegisterServiceRequest.java
@@ -1,0 +1,19 @@
+package im.fooding.app.dto.request.waiting;
+
+import lombok.Builder;
+
+@Builder
+public record WaitingRegisterServiceRequest(
+        long storeId,
+        String name,
+        String phoneNumber,
+        boolean termsAgreed,
+        boolean privacyPolicyAgreed,
+        boolean thirdPartyAgreed,
+        boolean marketingConsent,
+        String channel,
+        int infantChairCount,
+        int infantCount,
+        int adultCount
+) {
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingRegisterResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingRegisterResponse.java
@@ -1,0 +1,14 @@
+package im.fooding.app.dto.response.waiting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WaitingRegisterResponse(
+        @Schema(description = "호출 번호", example = "1")
+        long callNumber
+) {
+
+
+    public static WaitingRegisterResponse from(WaitingRegisterServiceResponse serviceResponse) {
+        return new WaitingRegisterResponse(serviceResponse.callNumber());
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingRegisterServiceResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingRegisterServiceResponse.java
@@ -1,0 +1,6 @@
+package im.fooding.app.dto.response.waiting;
+
+public record WaitingRegisterServiceResponse(
+        long callNumber
+) {
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/WaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/WaitingApplicationService.java
@@ -1,0 +1,61 @@
+package im.fooding.app.service.waiting;
+
+import im.fooding.app.dto.request.waiting.WaitingRegisterServiceRequest;
+import im.fooding.app.dto.response.waiting.WaitingRegisterServiceResponse;
+import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
+import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.service.waiting.StoreService;
+import im.fooding.core.service.waiting.StoreWaitingService;
+import im.fooding.core.service.waiting.WaitingLogService;
+import im.fooding.core.service.waiting.WaitingUserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class WaitingApplicationService {
+
+    private final StoreService storeService;
+    private final WaitingUserService waitingUserService;
+    private final StoreWaitingService storeWaitingService;
+    private final WaitingLogService waitingLogService;
+
+    public WaitingRegisterServiceResponse register(WaitingRegisterServiceRequest request) {
+        long storeId = request.storeId();
+        String phoneNumber = request.phoneNumber();
+
+        Store store = storeService.getById(storeId);
+
+        WaitingUserRegisterRequest waitingUserRegisterRequest = WaitingUserRegisterRequest.builder()
+                .store(store)
+                .name(request.name())
+                .phoneNumber(phoneNumber)
+                .termsAgreed(request.termsAgreed())
+                .privacyPolicyAgreed(request.privacyPolicyAgreed())
+                .thirdPartyAgreed(request.thirdPartyAgreed())
+                .marketingConsent(request.marketingConsent())
+                .build();
+        WaitingUser waitingUser = waitingUserService.getOrElseRegister(waitingUserRegisterRequest);
+
+        StoreWaitingRegisterRequest storeWaitingRegisterRequest = StoreWaitingRegisterRequest.builder()
+                .user(waitingUser)
+                .store(store)
+                .channel(request.channel())
+                .infantChairCount(request.infantChairCount())
+                .infantCount(request.infantCount())
+                .adultCount(request.adultCount())
+                .build();
+        StoreWaiting storeWaiting = storeWaitingService.register(storeWaitingRegisterRequest);
+
+        waitingLogService.logRegister(storeWaiting);
+
+        return new WaitingRegisterServiceResponse(storeWaiting.getCallNumber());
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/StoreWaitingRegisterRequest.java
+++ b/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/StoreWaitingRegisterRequest.java
@@ -1,0 +1,16 @@
+package im.fooding.core.dto.request.waiting;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingUser;
+import lombok.Builder;
+
+@Builder
+public record StoreWaitingRegisterRequest(
+        WaitingUser user,
+        Store store,
+        String channel,
+        int infantChairCount,
+        int infantCount,
+        int adultCount
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/WaitingUserRegisterRequest.java
+++ b/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/WaitingUserRegisterRequest.java
@@ -1,0 +1,29 @@
+package im.fooding.core.dto.request.waiting;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingUser;
+import lombok.Builder;
+
+@Builder
+public record WaitingUserRegisterRequest(
+        Store store,
+        String name,
+        String phoneNumber,
+        boolean termsAgreed,
+        boolean privacyPolicyAgreed,
+        boolean thirdPartyAgreed,
+        boolean marketingConsent
+) {
+
+    public WaitingUser toWaitingUser() {
+        return WaitingUser.builder()
+                .store(store)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .termsAgreed(termsAgreed)
+                .privacyPolicyAgreed(privacyPolicyAgreed)
+                .thirdPartyAgreed(thirdPartyAgreed)
+                .marketingConsent(marketingConsent)
+                .build();
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -23,7 +23,11 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "1000", "가입된 정보가 없습니다."),
     LOGIN_FAILED(HttpStatus.BAD_REQUEST, "1001", "로그인에 실패하셨습니다."),
     DUPLICATED_REGISTER_EMAIL(HttpStatus.BAD_REQUEST, "1002", "이미 가입된 이메일입니다."),
-    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "1003", "이미 가입된 닉네임입니다.");
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "1003", "이미 가입된 닉네임입니다."),
+
+    // 가게
+    STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2000", "등록된 가게 정보가 없습니다.")
+    ;
 
     private final HttpStatus status;
 

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -1,6 +1,7 @@
 package im.fooding.core.model.waiting;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.store.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -14,11 +15,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
-// todo: Store 객체 추가
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,9 +31,9 @@ public class StoreWaiting extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "waiting_user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -57,17 +58,17 @@ public class StoreWaiting extends BaseEntity {
     @Column(name = "memo", nullable = false)
     private String memo;
 
-//    @Builder
-//    public StoreWaiting(WaitingUser user, Store store, int callNumber, WaitingChannel channel, int infantChairCount, int infantCount, int adultCount) {
-//        this.user = user;
-//        this.store = sotre;
-//        this.callNumber = callNumber;
-//        this.channel = channel;
-//        this.infantChairCount = infantChairCount;
-//        this.infantCount = infantCount;
-//        this.adultCount = adultCount;
-//        this.memo = "";
-//    }
+    @Builder
+    public StoreWaiting(WaitingUser user, Store store, int callNumber, StoreWaitingChannel channel, int infantChairCount, int infantCount, int adultCount) {
+        this.user = user;
+        this.store = store;
+        this.callNumber = callNumber;
+        this.channel = channel;
+        this.infantChairCount = infantChairCount;
+        this.infantCount = infantCount;
+        this.adultCount = adultCount;
+        this.memo = "";
+    }
 
     public void updateMemo(String memo) {
         this.memo = memo;

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaitingChannel.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaitingChannel.java
@@ -1,7 +1,25 @@
 package im.fooding.core.model.waiting;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum StoreWaitingChannel {
-    IN_PERSON,
-    ONLINE
+
+    IN_PERSON("IN_PERSON"),
+    ONLINE("ONLINE")
     ;
+
+    private final String value;
+
+    public static StoreWaitingChannel of(String value) {
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ErrorCode.METHOD_ARGUMENT_NOT_VALID);
+        }
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingLog.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingLog.java
@@ -36,8 +36,12 @@ public class WaitingLog extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private WaitingLogType type;
 
-    public WaitingLog(StoreWaiting storeWaiting, WaitingLogType type) {
+    public WaitingLog(StoreWaiting storeWaiting) {
         this.storeWaiting = storeWaiting;
-        this.type = type;
+        this.type = WaitingLogType.WAITING_REGISTRATION;
+    }
+
+    public void entry() {
+        this.type = WaitingLogType.ENTRY;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
@@ -1,17 +1,23 @@
 package im.fooding.core.model.waiting;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.store.Store;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
-// todo: Store 객체 추가
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,9 +28,9 @@ public class WaitingUser extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
 
     private String name;
 
@@ -46,16 +52,17 @@ public class WaitingUser extends BaseEntity {
     @Column(nullable = false)
     private int count;
 
-//    @Builder
-//    public WaitingUser(Store store, String name, String phoneNumber, boolean termsAgreed, boolean privacyPolicyAgreed, boolean thirdPartyAgreed, boolean marketingConsent) {
-//        this.name = name;
-//        this.phoneNumber = phoneNumber;
-//        this.termsAgreed = termsAgreed;
-//        this.privacyPolicyAgreed = privacyPolicyAgreed;
-//        this.thirdPartyAgreed = thirdPartyAgreed;
-//        this.marketingConsent = marketingConsent;
-//        this.count = 0;
-//    }
+    @Builder
+    public WaitingUser(Store store, String name, String phoneNumber, boolean termsAgreed, boolean privacyPolicyAgreed, boolean thirdPartyAgreed, boolean marketingConsent) {
+        this.store = store;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.termsAgreed = termsAgreed;
+        this.privacyPolicyAgreed = privacyPolicyAgreed;
+        this.thirdPartyAgreed = thirdPartyAgreed;
+        this.marketingConsent = marketingConsent;
+        this.count = 0;
+    }
 
     public void visitStore() {
         count++;

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/StoreRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/StoreRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.store;
+
+import im.fooding.core.model.store.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepository.java
@@ -1,0 +1,5 @@
+package im.fooding.core.repository.waiting;
+
+public interface QStoreWaitingRepository {
+    long countTodayCreated();
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepositoryImpl.java
@@ -1,0 +1,28 @@
+package im.fooding.core.repository.waiting;
+
+import static im.fooding.core.model.waiting.QStoreWaiting.storeWaiting;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QStoreWaitingRepositoryImpl implements QStoreWaitingRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public long countTodayCreated() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = LocalDate.now().atTime(LocalTime.MAX);
+
+        return query
+                .selectFrom(storeWaiting)
+                .where(storeWaiting.createdAt.between(start, end))
+                .fetch().size();
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
@@ -1,0 +1,8 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.repository.waiting.QStoreWaitingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreWaitingRepository extends JpaRepository<StoreWaiting, Long>, QStoreWaitingRepository {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingLogRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingLogRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.WaitingLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingLogRepository extends JpaRepository<WaitingLog, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingRepository.java
@@ -1,0 +1,9 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.Waiting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+
+
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingUserRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingUserRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WaitingUserRepository extends JpaRepository<WaitingUser, Long> {
+
+    Optional<WaitingUser> findByStoreAndPhoneNumber(Store store, String phoneNumber);
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreService.java
@@ -1,0 +1,24 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.repository.store.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    public Store getById(long id) {
+        return storeRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.STORE_NOT_FOUND));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -1,0 +1,35 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.repository.waiting.StoreWaitingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class StoreWaitingService {
+
+    private final StoreWaitingRepository storeWaitingRepository;
+
+    public StoreWaiting register(StoreWaitingRegisterRequest request) {
+        int callNumber = (int) storeWaitingRepository.countTodayCreated() + 1;
+
+        StoreWaiting storeWaiting = StoreWaiting.builder()
+                .user(request.user())
+                .store(request.store())
+                .callNumber(callNumber)
+                .channel(StoreWaitingChannel.of(request.channel()))
+                .infantChairCount(request.infantChairCount())
+                .infantCount(request.infantCount())
+                .adultCount(request.adultCount())
+                .build();
+
+        return storeWaitingRepository.save(storeWaiting);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingLogService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingLogService.java
@@ -1,0 +1,24 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.WaitingLog;
+import im.fooding.core.model.waiting.WaitingLogType;
+import im.fooding.core.repository.waiting.WaitingLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class WaitingLogService {
+
+    private final WaitingLogRepository waitingLogRepository;
+
+    public WaitingLog logRegister(StoreWaiting storeWaiting) {
+        return waitingLogRepository.save(new WaitingLog(storeWaiting));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingUserService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingUserService.java
@@ -1,0 +1,27 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.waiting.WaitingUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class WaitingUserService {
+
+    private final WaitingUserRepository waitingUserRepository;
+
+    public WaitingUser getOrElseRegister(WaitingUserRegisterRequest request) {
+        return waitingUserRepository.findByStoreAndPhoneNumber(request.store(), request.phoneNumber())
+                .orElseGet(() -> register(request));
+    }
+
+    private WaitingUser register(WaitingUserRegisterRequest request) {
+        return waitingUserRepository.saveAndFlush(request.toWaitingUser());
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreServiceTest.java
@@ -1,0 +1,37 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.TestConfig;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.repository.store.StoreRepository;
+import im.fooding.core.support.dummy.StoreDummy;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestConstructor;
+
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class StoreServiceTest extends TestConfig {
+
+    private final StoreRepository storeRepository;
+    private final StoreService storeService;
+
+    @AfterEach
+    void tearDown() {
+        storeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("id로 가게를 조회할 수 있다.")
+    public void get_store_by_id() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+
+        // when & then
+        Assertions.assertThat(storeService.getById(store.getId()))
+                .isNotNull();
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
@@ -1,0 +1,73 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.TestConfig;
+import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.store.StoreRepository;
+import im.fooding.core.repository.waiting.StoreWaitingRepository;
+import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.StoreDummy;
+import im.fooding.core.support.dummy.WaitingUserDummy;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestConstructor;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class StoreWaitingServiceTest extends TestConfig {
+
+    private final StoreWaitingService storeWaitingService;
+    private final StoreWaitingRepository storeWaitingRepository;
+    private final StoreRepository storeRepository;
+    private final WaitingUserRepository waitingUserRepository;
+
+    @AfterEach
+    void tearDown() {
+        storeWaitingRepository.deleteAll();
+        storeRepository.deleteAll();
+        waitingUserRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("웨이팅 등록시 가게의 현재 웨이팅 개수 + 1의 호출 번호로 등록된다.")
+    public void callNumber_is_current_waiting_count_plus_1_when_register() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser user1 = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01012345678"));
+        WaitingUser user2 = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01023456789"));
+
+        StoreWaitingRegisterRequest user1Request = StoreWaitingRegisterRequest.builder()
+                .user(user1)
+                .store(store)
+                .channel(StoreWaitingChannel.IN_PERSON.getValue())
+                .infantChairCount(1)
+                .infantCount(1)
+                .adultCount(1)
+                .build();
+
+        StoreWaitingRegisterRequest user2Request = StoreWaitingRegisterRequest.builder()
+                .user(user2)
+                .store(store)
+                .channel(StoreWaitingChannel.IN_PERSON.getValue())
+                .infantChairCount(1)
+                .infantCount(1)
+                .adultCount(1)
+                .build();
+
+        // when
+        StoreWaiting user1StoreWaiting = storeWaitingService.register(user1Request);
+        StoreWaiting user2StoreWaiting = storeWaitingService.register(user2Request);
+
+        // then
+        Assertions.assertThat(user1StoreWaiting.getCallNumber())
+                .isEqualTo(1);
+        Assertions.assertThat(user2StoreWaiting.getCallNumber())
+                .isEqualTo(2);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingLogServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingLogServiceTest.java
@@ -1,0 +1,63 @@
+package im.fooding.core.service.waiting;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import im.fooding.core.TestConfig;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.WaitingLog;
+import im.fooding.core.model.waiting.WaitingLogType;
+import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.store.StoreRepository;
+import im.fooding.core.repository.waiting.StoreWaitingRepository;
+import im.fooding.core.repository.waiting.WaitingLogRepository;
+import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.StoreDummy;
+import im.fooding.core.support.dummy.StoreWaitingDummy;
+import im.fooding.core.support.dummy.WaitingUserDummy;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestConstructor;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class WaitingLogServiceTest extends TestConfig {
+
+    private final WaitingLogService waitingLogService;
+    private final WaitingLogRepository waitingLogRepository;
+    private final WaitingUserRepository waitingUserRepository;
+    private final StoreRepository storeRepository;
+    private final StoreWaitingRepository storeWaitingRepository;
+
+    @AfterEach
+    void tearDown() {
+        waitingLogRepository.deleteAll();
+        waitingUserRepository.deleteAll();
+        storeRepository.deleteAll();
+        storeWaitingRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("register 로그를 남기면 WAITING_REGISTRATION 으로 로그가 남아야 한다.")
+    public void save_WAITING_REGISTRATION_when_log_register() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser user = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01012345678"));
+        StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
+
+        // when
+        WaitingLog waitingLog = waitingLogService.logRegister(storeWaiting);
+
+        // then
+        List<WaitingLog> waitingLogs = waitingLogRepository.findAll();
+        Assertions.assertThat(waitingLogs)
+                .hasSize(1);
+
+        Assertions.assertThat(waitingLog.getType())
+                .isEqualTo(WaitingLogType.WAITING_REGISTRATION);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingUserServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingUserServiceTest.java
@@ -1,0 +1,78 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.TestConfig;
+import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.store.StoreRepository;
+import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.StoreDummy;
+import im.fooding.core.support.dummy.WaitingUserDummy;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestConstructor;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class WaitingUserServiceTest extends TestConfig {
+
+    private final WaitingUserService waitingUserService;
+    private final WaitingUserRepository waitingUserRepository;
+    private final StoreRepository storeRepository;
+
+    @AfterEach
+    void tearDown() {
+        waitingUserRepository.deleteAll();
+        storeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("웨이팅 유저가 없는 경우 새로 등록한다.")
+    void register_when_not_exist_waiting_user() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+
+        WaitingUserRegisterRequest request = WaitingUserRegisterRequest.builder()
+                .store(store)
+                .name("name")
+                .phoneNumber("01012345678")
+                .termsAgreed(true)
+                .privacyPolicyAgreed(true)
+                .thirdPartyAgreed(true)
+                .marketingConsent(true)
+                .build();
+
+        // when & then
+        Assertions.assertThat(waitingUserService.getOrElseRegister(request))
+                .isNotNull();
+        Assertions.assertThat(waitingUserRepository.findAll())
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("웨이팅 유저가 있다면 존재하는 유저를 가져온다.")
+    void get_when_exist_waiting_user() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser waitingUser = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01012345678"));
+
+        WaitingUserRegisterRequest request = WaitingUserRegisterRequest.builder()
+                .store(store)
+                .name("name")
+                .phoneNumber(waitingUser.getPhoneNumber())
+                .termsAgreed(true)
+                .privacyPolicyAgreed(true)
+                .thirdPartyAgreed(true)
+                .marketingConsent(true)
+                .build();
+
+        // when & then
+        Assertions.assertThat(waitingUserService.getOrElseRegister(request))
+                .isNotNull();
+        Assertions.assertThat(waitingUserRepository.findAll())
+                .hasSize(1);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
@@ -1,0 +1,24 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+
+public class StoreDummy {
+
+    public static Store create() {
+        return Store.builder()
+                .name("name")
+                .city("city")
+                .address("address")
+                .category("category")
+                .description("description")
+                .contactNumber("01012345678")
+                .priceCategory("priceCategory")
+                .eventDescription("eventDescription")
+                .direction("direction")
+                .information("information")
+                .isParkingAvailable(true)
+                .isNewOpen(true)
+                .isTakeOut(true)
+                .build();
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreWaitingDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreWaitingDummy.java
@@ -1,0 +1,21 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.WaitingUser;
+
+public class StoreWaitingDummy {
+
+    public static StoreWaiting create(WaitingUser user, Store store) {
+        return StoreWaiting.builder()
+                .user(user)
+                .store(store)
+                .callNumber(1)
+                .channel(StoreWaitingChannel.IN_PERSON)
+                .infantChairCount(1)
+                .infantCount(1)
+                .adultCount(1)
+                .build();
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingUserDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingUserDummy.java
@@ -1,0 +1,19 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingUser;
+
+public class WaitingUserDummy {
+
+    public static WaitingUser createWithPhoneNumber(Store store, String phoneNumber) {
+        return WaitingUser.builder()
+                .store(store)
+                .name("name")
+                .phoneNumber(phoneNumber)
+                .termsAgreed(true)
+                .privacyPolicyAgreed(true)
+                .thirdPartyAgreed(true)
+                .marketingConsent(true)
+                .build();
+    }
+}


### PR DESCRIPTION
### 관련 티켓
[[App] Waiting API 개발](https://www.notion.so/benkang/App-Waiting-API-1cd83feabad3800ba033d3649ad6566b?pvs=4)

## 주요 변경 사항
### api
- 웨이팅 컨트롤러
  - 웨이팅 등록 end-point 추가
- 웨이팅 애플리케이션 서비스
  - 등록 메서드 추가

### core
- 가게 서비스
  - id로 entity 조회 기능 추가 (getById 메서드)
- 웨이팅 유저 서비스
  - 웨이팅 유저 조회 or 등록 기능 추가 (getOrElseRegister 메서드)
- 가게 웨이팅 서비스
  - 등록 기능 추가 (register 메서드)
- 웨이팅 로그 서비스
  - 등록 로깅 기능 추가 (logRegister 메서드)
- 관련 테스트 추가

### 수동 테스트
- config 파일 코드를 잠시 permitAll()로 변경하여 Postman 이용하여 테스트 했습니다.