### PR TITLE
[BE-20] CEO들의 Device 목록 조회 / [BE-21] Admin의 Device 목록 조회

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/device/AdminDeviceController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/device/AdminDeviceController.java
@@ -1,0 +1,34 @@
+package im.fooding.app.controller.admin.device;
+
+import im.fooding.app.dto.request.admin.device.RetrieveAllDeviceRequest;
+import im.fooding.app.dto.response.user.device.StoreDeviceResponse;
+import im.fooding.app.service.user.device.DeviceApplicationService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/device")
+@Tag(name="Admin Device Controller", description = "관리자 디바이스 컨트롤러")
+public class AdminDeviceController {
+    private final DeviceApplicationService service;
+
+    @GetMapping("/retrieveALlDevice")
+    @Operation(summary="모든 디바이스 조회")
+    public ApiResult<PageResponse<StoreDeviceResponse>> retrieveAllDevice(
+            @RequestParam RetrieveAllDeviceRequest request
+            ){
+        return ApiResult.ok(service.retrieveAllDevice( request ) );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/device/AdminDeviceController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/device/AdminDeviceController.java
@@ -14,19 +14,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/device")
+@RequestMapping("/admin/devices")
 @Tag(name="Admin Device Controller", description = "관리자 디바이스 컨트롤러")
 public class AdminDeviceController {
     private final DeviceApplicationService service;
 
-    @GetMapping("/retrieveALlDevice")
+    @GetMapping()
     @Operation(summary="모든 디바이스 조회")
-    public ApiResult<PageResponse<StoreDeviceResponse>> retrieveAllDevice(
+    public ApiResult<PageResponse<StoreDeviceResponse>> list(
             @RequestParam RetrieveAllDeviceRequest request
             ){
         return ApiResult.ok(service.retrieveAllDevice( request ) );

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/device/UserDeviceController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/device/UserDeviceController.java
@@ -7,6 +7,7 @@ import im.fooding.core.common.ApiResult;
 import im.fooding.core.common.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -16,15 +17,15 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user/device")
+@RequestMapping("/user/devices")
 @Tag(name = "User Device Controller", description = "사용자 디바이스 컨트롤러")
 public class UserDeviceController {
     private final DeviceApplicationService service;
 
-    @GetMapping("/retrieveStoreDevice")
+    @GetMapping("")
     @Operation(summary="가게 소속 디바이스 조회")
-    public ApiResult<PageResponse<StoreDeviceResponse>> retrieveStoreDevice(
-            @RequestBody RetrieveStoreDeviceRequest request
+    public ApiResult<PageResponse<StoreDeviceResponse>> retrieve(
+            @Valid RetrieveStoreDeviceRequest request
     ) {
         return ApiResult.ok(service.retrieveStoreDevice( request ));
     }

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/device/UserDeviceController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/device/UserDeviceController.java
@@ -1,0 +1,31 @@
+package im.fooding.app.controller.user.device;
+
+import im.fooding.app.dto.request.user.device.RetrieveStoreDeviceRequest;
+import im.fooding.app.dto.response.user.device.StoreDeviceResponse;
+import im.fooding.app.service.user.device.DeviceApplicationService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/device")
+@Tag(name = "User Device Controller", description = "사용자 디바이스 컨트롤러")
+public class UserDeviceController {
+    private final DeviceApplicationService service;
+
+    @GetMapping("/retrieveStoreDevice")
+    @Operation(summary="가게 소속 디바이스 조회")
+    public ApiResult<PageResponse<StoreDeviceResponse>> retrieveStoreDevice(
+            @RequestBody RetrieveStoreDeviceRequest request
+    ) {
+        return ApiResult.ok(service.retrieveStoreDevice( request ));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/device/RetrieveAllDeviceRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/device/RetrieveAllDeviceRequest.java
@@ -3,8 +3,10 @@ package im.fooding.app.dto.request.admin.device;
 import im.fooding.core.common.BasicSearch;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class RetrieveAllDeviceRequest extends BasicSearch {
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/device/RetrieveAllDeviceRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/device/RetrieveAllDeviceRequest.java
@@ -1,0 +1,10 @@
+package im.fooding.app.dto.request.admin.device;
+
+import im.fooding.core.common.BasicSearch;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RetrieveAllDeviceRequest extends BasicSearch {
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/device/RetrieveStoreDeviceRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/device/RetrieveStoreDeviceRequest.java
@@ -1,0 +1,15 @@
+package im.fooding.app.dto.request.user.device;
+
+import im.fooding.core.common.BasicSearch;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RetrieveStoreDeviceRequest extends BasicSearch {
+    @NotNull
+    @Schema( description = "가게 ID", example="1")
+    private Long storeId;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/device/RetrieveStoreDeviceRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/device/RetrieveStoreDeviceRequest.java
@@ -5,8 +5,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class RetrieveStoreDeviceRequest extends BasicSearch {
     @NotNull

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/device/StoreDeviceResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/device/StoreDeviceResponse.java
@@ -34,7 +34,14 @@ public class StoreDeviceResponse {
     private ServiceType serviceType;
 
     @Builder
-    private StoreDeviceResponse(long id, DeviceType deviceType, String name, String osVersion, LocalDateTime installedAt, LocalDateTime lastConnectedAt, ServiceType serviceType ){
+    private StoreDeviceResponse(
+            long id, DeviceType deviceType,
+            String name,
+            String osVersion,
+            LocalDateTime installedAt,
+            LocalDateTime lastConnectedAt,
+            ServiceType serviceType
+    ){
         this.id = id;
         this.deviceType = deviceType;
         this.name = name;

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/device/StoreDeviceResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/device/StoreDeviceResponse.java
@@ -1,0 +1,58 @@
+package im.fooding.app.dto.response.user.device;
+
+import im.fooding.core.model.device.Device;
+import im.fooding.core.model.device.DeviceType;
+import im.fooding.core.model.device.ServiceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class StoreDeviceResponse {
+    @Schema(description = "id", example = "1" )
+    private long id;
+
+    @Schema(description = "디바이스 종류", example = "IOS")
+    private DeviceType deviceType;
+
+    @Schema(description = "디바이스 이름", example = "iPad 12")
+    private String name;
+
+    @Schema(description = "디바이스 OS 버젼", example = "iOS 17")
+    private String osVersion;
+
+    @Schema( description = "설치 일자", example="2025-04-07 17:52:33")
+    private LocalDateTime installedAt;
+
+    @Schema(description = "마지막 접속 일자", example="2025-04-09 18:20:45" )
+    private LocalDateTime lastConnectedAt;
+
+    @Schema(description = "현재 서비스 타입", example="REWARD_MANAGEMENT")
+    private ServiceType serviceType;
+
+    @Builder
+    private StoreDeviceResponse(long id, DeviceType deviceType, String name, String osVersion, LocalDateTime installedAt, LocalDateTime lastConnectedAt, ServiceType serviceType ){
+        this.id = id;
+        this.deviceType = deviceType;
+        this.name = name;
+        this.osVersion = osVersion;
+        this.installedAt = installedAt;
+        this.lastConnectedAt = lastConnectedAt;
+        this.serviceType = serviceType;
+    }
+
+    public static StoreDeviceResponse of(Device device){
+        return StoreDeviceResponse.builder()
+                .id(device.getId())
+                .deviceType(device.getType())
+                .name(device.getName())
+                .osVersion(device.getOsVersion())
+                .installedAt(device.getInstalledAt())
+                .lastConnectedAt(device.getLastConnectedAt())
+                .serviceType(device.getServiceType())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/device/DeviceApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/device/DeviceApplicationService.java
@@ -1,0 +1,51 @@
+package im.fooding.app.service.user.device;
+
+import im.fooding.app.dto.request.admin.device.RetrieveAllDeviceRequest;
+import im.fooding.app.dto.request.user.device.RetrieveStoreDeviceRequest;
+import im.fooding.app.dto.response.user.device.StoreDeviceResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.device.Device;
+import im.fooding.core.service.device.DeviceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceApplicationService {
+    private final DeviceService deviceService;
+
+    /**
+     * store id로 조회
+     *
+     * @param request
+     * @return StoreDeviceResponse
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<StoreDeviceResponse> retrieveStoreDevice(RetrieveStoreDeviceRequest request ){
+        Pageable pageable = PageRequest.of(request.getPageNum(), request.getPageSize() );
+        Page<Device> result = deviceService.findByStoreId(request.getSearchString(), request.getStoreId(), pageable );
+        PageInfo pageInfo = PageInfo.of( result );
+        return PageResponse.of( result.getContent().stream().map(StoreDeviceResponse::of).collect(Collectors.toList()), pageInfo );
+    }
+
+    /**
+     * 모든 디바이스 조회
+     *
+     * @param request
+     * @return StoreDeviceResponse
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<StoreDeviceResponse> retrieveAllDevice(RetrieveAllDeviceRequest request ){
+        Pageable pageable = PageRequest.of(request.getPageNum(), request.getPageSize() );
+        Page<Device> result = deviceService.findAllDevice(pageable);
+        return PageResponse.of( result.getContent().stream().map(StoreDeviceResponse::of).collect(Collectors.toList()), PageInfo.of( result ) );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/device/DeviceApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/device/DeviceApplicationService.java
@@ -31,7 +31,7 @@ public class DeviceApplicationService {
     @Transactional(readOnly = true)
     public PageResponse<StoreDeviceResponse> retrieveStoreDevice(RetrieveStoreDeviceRequest request ){
         Pageable pageable = PageRequest.of(request.getPageNum(), request.getPageSize() );
-        Page<Device> result = deviceService.findByStoreId(request.getSearchString(), request.getStoreId(), pageable );
+        Page<Device> result = deviceService.list(request.getSearchString(), request.getStoreId(), pageable );
         PageInfo pageInfo = PageInfo.of( result );
         return PageResponse.of( result.getContent().stream().map(StoreDeviceResponse::of).collect(Collectors.toList()), pageInfo );
     }
@@ -45,7 +45,7 @@ public class DeviceApplicationService {
     @Transactional(readOnly = true)
     public PageResponse<StoreDeviceResponse> retrieveAllDevice(RetrieveAllDeviceRequest request ){
         Pageable pageable = PageRequest.of(request.getPageNum(), request.getPageSize() );
-        Page<Device> result = deviceService.findAllDevice(pageable);
+        Page<Device> result = deviceService.list(null, Long.MIN_VALUE, pageable);
         return PageResponse.of( result.getContent().stream().map(StoreDeviceResponse::of).collect(Collectors.toList()), PageInfo.of( result ) );
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
     EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "1005", "이메일 제공 동의가 필요합니다."),
 
     // 디바이스
-    DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2000", "등록된 디바이스가 없습니다."),
+    DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "7000", "등록된 디바이스가 없습니다."),
     ;
     private final HttpStatus status;
 

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "1003", "이미 가입된 닉네임입니다."),
     UNSUPPORTED_SOCIAL(HttpStatus.BAD_REQUEST, "1004", "지원하지 않는 소셜로그인 입니다."),
     EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "1005", "이메일 제공 동의가 필요합니다."),
+
+    // 디바이스
+    DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2000", "등록된 디바이스가 없습니다."),
     ;
     private final HttpStatus status;
 

--- a/fooding-core/src/main/java/im/fooding/core/model/device/Device.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/device/Device.java
@@ -1,6 +1,7 @@
 package im.fooding.core.model.device;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.store.Store;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,9 +21,9 @@ public class Device extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
 
     @Column(name = "name")
     private String name;

--- a/fooding-core/src/main/java/im/fooding/core/repository/device/DeviceRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/device/DeviceRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.device;
+
+import im.fooding.core.model.device.Device;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeviceRepository extends JpaRepository<Device, Long>, QDeviceRepository {
+    Page<Device> findAllByNotDeleted( Pageable pageable );
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/device/DeviceRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/device/DeviceRepository.java
@@ -1,12 +1,8 @@
 package im.fooding.core.repository.device;
 
 import im.fooding.core.model.device.Device;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface DeviceRepository extends JpaRepository<Device, Long>, QDeviceRepository {
-    Page<Device> findAllByNotDeleted( Pageable pageable );
+
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepository.java
@@ -1,0 +1,9 @@
+package im.fooding.core.repository.device;
+
+import im.fooding.core.model.device.Device;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QDeviceRepository {
+    Page<Device> list(String searchString, Pageable pageable, long storeId );
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface QDeviceRepository {
-    Page<Device> list(String searchString, Pageable pageable, long storeId );
+    Page<Device> list(String searchString, Pageable pageable, Long storeId );
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepositoryImpl.java
@@ -23,7 +23,7 @@ public class QDeviceRepositoryImpl implements QDeviceRepository{
         BooleanBuilder condition = new BooleanBuilder();
         condition.and( device.deleted.isFalse() );
         if( search( searchString ) != null ) condition.and( search( searchString ) );
-        if( storeId != null ) condition.and( device.store.id.eq( storeId ) );
+        if( storeId != Long.MIN_VALUE ) condition.and( device.store.id.eq( storeId ) );
 
         List<Device> results = query
                 .select(device)

--- a/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/device/QDeviceRepositoryImpl.java
@@ -1,0 +1,47 @@
+package im.fooding.core.repository.device;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.model.device.Device;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static im.fooding.core.model.device.QDevice.device;
+
+@RequiredArgsConstructor
+public class QDeviceRepositoryImpl implements QDeviceRepository{
+    private final JPAQueryFactory query;
+    @Override
+    public Page<Device> list(String searchString, Pageable pageable, long storeId) {
+        List<Device> results = query
+                .select(device)
+                .from(device)
+                .where(
+                        device.deleted.isFalse(),
+                        device.store.id.eq( storeId ),
+                        search(searchString)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Device> countQuery = query
+                .select(device)
+                .from(device)
+                .where(
+                        device.deleted.isFalse(),
+                        search(searchString)
+                );
+        return PageableExecutionUtils.getPage( results, pageable, countQuery::fetchCount );
+    }
+
+    private BooleanExpression search(String searchString){
+        return StringUtils.hasText(searchString)
+                ? device.name.contains(searchString) : null;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/device/DeviceService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/device/DeviceService.java
@@ -1,0 +1,37 @@
+package im.fooding.core.service.device;
+
+import im.fooding.core.model.device.Device;
+import im.fooding.core.repository.device.DeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeviceService {
+    private final DeviceRepository deviceRepository;
+
+    /**
+     * Store ID로 리스트 조회
+     *
+     * @param storeId
+     * @param pageable
+     * @return Page<Device>
+     */
+    public Page<Device> findByStoreId(String searchString, long storeId, Pageable pageable){
+        return deviceRepository.list(searchString, pageable, storeId);
+    }
+
+    /**
+     * 모든 Device 리스트 조회
+     *
+     * @param pageable
+     * @return Page<Device>
+     */
+    public Page<Device> findAllDevice(Pageable pageable){
+        return deviceRepository.findAllByNotDeleted(pageable);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/device/DeviceService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/device/DeviceService.java
@@ -15,23 +15,14 @@ public class DeviceService {
     private final DeviceRepository deviceRepository;
 
     /**
-     * Store ID로 리스트 조회
+     * 디바이스 목록 조회
      *
+     * @param searchString
      * @param storeId
      * @param pageable
      * @return Page<Device>
      */
-    public Page<Device> findByStoreId(String searchString, long storeId, Pageable pageable){
+    public Page<Device> list(String searchString, long storeId, Pageable pageable){
         return deviceRepository.list(searchString, pageable, storeId);
-    }
-
-    /**
-     * 모든 Device 리스트 조회
-     *
-     * @param pageable
-     * @return Page<Device>
-     */
-    public Page<Device> findAllDevice(Pageable pageable){
-        return deviceRepository.findAllByNotDeleted(pageable);
     }
 }


### PR DESCRIPTION
**[BE-20] 각 가게에서 사용하고 있는 Device 목록 조회**
[BE-20 CEO의 Device 목록 조회](https://www.notion.so/benkang/CEO-Device-API-1ce83feabad380b9b944f595c4a058ea)
**[BE-21] Admin의 모든 Device 목록 조회**
[BE-21 Admin의 Device 목록 조회](https://www.notion.so/benkang/ADMIN-Device-API-1ce83feabad3801191c6c2178a265d72)

**p.s.**
- 원래 두 백로그를 따로 개발하고 PR하는게 맞지만... 두 기능이 너무 유사한 기능이며 간단한 기능이기에 한 번에 제작하고 PR 올립니다.
- 하나 백로그 태우고 이후에 다른 백로그를 태워도 되지만 두 백로그 모두 같은 파일을 건드려서 하나의 백로그가 merge 될 때까지 기다리면 시간이 너무 지연될 것 같아 이렇게 진행했다는 점 양해 부탁드립니다. 
- 만약 시간이 지연되더라도 Git 및 버전 관리를 위해 따로 하는 것이 좋다고 말씀해주시면 다음부터는 그렇게 하도록 하겠습니다(ㅠㅠ)

**[ API ]**
UserDeviceController 제작 - 사용자가 접근하는 컨트롤러
AdminDeviceControlelr 제작 - 관리자가 접근하는 컨트롤러
DeviceApplicationService 제작 - Device 관련 데이터에 로직을 더하는 서비스
RetrieveStoreDeviceRequest 제작 - 해당 가게의 Device 목록 조회를 위한 DTO 제작 / Page 사용
RetrieveAllDeviceRequest 제작  - 모든 Device 목록 조회를 위한 DTO 제작 / Page 사용
StoreDeviceResponse 제작 - Device 목록을 가져오기 위한 DTO 제작

**[ Core ]**
DeviceService 제작 - 실제 Device Repository와 통신하는 서비스
DeviceRepository 제작 - Device 도메인 정보를 가져오기 위한 JPA 레포지토리 제작
QDeviceRepository 제작 - Device Repsitory에 Query 사용을 위한 인터페이스 제작
QDeviceRepositoryImpl 제작 - Device Repository 사용에 필요한 쿼리 로직 구현을 위한 Implement 제작

