### PR TITLE
[BE-22] 웨이팅 목록 조회 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
@@ -1,0 +1,34 @@
+package im.fooding.app.controller.waiting;
+
+import im.fooding.app.dto.request.waiting.WaitingListByStoreIdRequest;
+import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.app.service.waiting.AppWaitingApplicationService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/app/waitings")
+@Tag(name = "AppWaitingController", description = "웨이팅 관리 컨트롤러")
+@Slf4j
+public class AppWaitingController {
+
+    private final AppWaitingApplicationService appWaitingApplicationService;
+
+    @GetMapping("/store/{storeId}")
+    @Operation(summary = "웨이팅 목록 조회")
+    ApiResult<PageResponse<WaitingResponse>> listByStoreId(
+            @Parameter(description = "가게 id", example = "1")
+            @PathVariable long storeId,
+
+            @RequestBody WaitingListByStoreIdRequest request
+    ) {
+        return ApiResult.ok(appWaitingApplicationService.listByStoreIdAndStatus(storeId, request));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/WaitingListByStoreIdRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/WaitingListByStoreIdRequest.java
@@ -1,0 +1,26 @@
+package im.fooding.app.dto.request.waiting;
+
+import im.fooding.core.common.BasicSearch;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.domain.Pageable;
+
+public record WaitingListByStoreIdRequest(
+        @Schema(description = "search 정보")
+        BasicSearch search,
+
+        @NotBlank
+        @Schema(description = "상태 (WAITING, SEATED, CANCELLED)", example = "WAITING")
+        String status
+) {
+
+    public WaitingListByStoreIdRequest {
+        if (search == null) {
+            search = new BasicSearch();
+        }
+    }
+
+    public Pageable pageable() {
+        return search.getPageable();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingResponse.java
@@ -1,0 +1,48 @@
+package im.fooding.app.dto.response.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WaitingResponse(
+        @Schema(description = "id", example = "1")
+        long id,
+
+        @Schema(description = "가게 id", example = "1")
+        long storeId,
+
+        @Schema(description = "유저 정보")
+        WaitingUserResponse user,
+
+        @Schema(description = "호출 번호", example = "1")
+        int callNumber,
+
+        @Schema(description = "등록 수단", example = "IN_PERSON")
+        String channel,
+
+        @Schema(description = "필요한 유아용 의자 개수", example = "1")
+        int infantChairCount,
+
+        @Schema(description = "유아 입장 인원수", example = "1")
+        int infantCount,
+
+        @Schema(description = "성인 입장 인원수", example = "1")
+        int adultCount,
+
+        @Schema(description = "메모", example = "this is memo.")
+        String memo
+) {
+
+    public static WaitingResponse from(StoreWaiting storeWaiting) {
+        return new WaitingResponse(
+                storeWaiting.getId(),
+                storeWaiting.getStoreId(),
+                WaitingUserResponse.from(storeWaiting.getUser()),
+                storeWaiting.getCallNumber(),
+                storeWaiting.getChannelValue(),
+                storeWaiting.getInfantChairCount(),
+                storeWaiting.getInfantCount(),
+                storeWaiting.getAdultCount(),
+                storeWaiting.getMemo()
+        );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingUserResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingUserResponse.java
@@ -1,0 +1,31 @@
+package im.fooding.app.dto.response.waiting;
+
+import im.fooding.core.model.waiting.WaitingUser;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WaitingUserResponse(
+        @Schema(description = "id", example = "1")
+        long id,
+
+        @Schema(description = "가게 id", example = "1")
+        long storeId,
+
+        @Schema(description = "이름", example = "홍길동")
+        String name,
+
+        @Schema(description = "전화번호", example = "01012345678")
+        String phoneNumber,
+
+        @Schema(description = "방문 횟수", example = "1")
+        int count
+) {
+    public static WaitingUserResponse from(WaitingUser waitingUser) {
+        return new WaitingUserResponse(
+                waitingUser.getId(),
+                waitingUser.getStoreId(),
+                waitingUser.getName(),
+                waitingUser.getPhoneNumber(),
+                waitingUser.getCount()
+        );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
@@ -1,0 +1,34 @@
+package im.fooding.app.service.waiting;
+
+import im.fooding.app.dto.request.waiting.WaitingListByStoreIdRequest;
+import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.service.waiting.StoreWaitingService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class AppWaitingApplicationService {
+
+    private final StoreWaitingService storeWaitingService;
+
+    public PageResponse<WaitingResponse> listByStoreIdAndStatus(long storeId, WaitingListByStoreIdRequest request) {
+        Page<StoreWaiting> storeWaitings = storeWaitingService.getAllByStoreIdAndStatus(storeId, request.status(), request.pageable());
+
+        List<WaitingResponse> list = storeWaitings.getContent()
+                .stream()
+                .map(WaitingResponse::from)
+                .toList();
+
+        return PageResponse.of(list, PageInfo.of(storeWaitings));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -1,6 +1,7 @@
 package im.fooding.core.model.waiting;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.store.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -14,11 +15,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
-// todo: Store 객체 추가
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,9 +31,9 @@ public class StoreWaiting extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "waiting_user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -40,6 +41,9 @@ public class StoreWaiting extends BaseEntity {
 
     @Column(name = "call_number", nullable = false)
     private int callNumber;
+
+    @Column(name = "store_waiting_status", nullable = false)
+    private StoreWaitingStatus status;
 
     @Column(name = "channel", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -57,19 +61,36 @@ public class StoreWaiting extends BaseEntity {
     @Column(name = "memo", nullable = false)
     private String memo;
 
-//    @Builder
-//    public StoreWaiting(WaitingUser user, Store store, int callNumber, WaitingChannel channel, int infantChairCount, int infantCount, int adultCount) {
-//        this.user = user;
-//        this.store = sotre;
-//        this.callNumber = callNumber;
-//        this.channel = channel;
-//        this.infantChairCount = infantChairCount;
-//        this.infantCount = infantCount;
-//        this.adultCount = adultCount;
-//        this.memo = "";
-//    }
+    @Builder
+    public StoreWaiting(WaitingUser user, Store store, int callNumber, StoreWaitingChannel channel, int infantChairCount, int infantCount, int adultCount) {
+        this.user = user;
+        this.store = store;
+        this.callNumber = callNumber;
+        this.status = StoreWaitingStatus.WAITING;
+        this.channel = channel;
+        this.infantChairCount = infantChairCount;
+        this.infantCount = infantCount;
+        this.adultCount = adultCount;
+        this.memo = "";
+    }
 
     public void updateMemo(String memo) {
         this.memo = memo;
+    }
+
+    public void seat() {
+        this.status = StoreWaitingStatus.SEATED;
+    }
+
+    public void cancel() {
+        this.status = StoreWaitingStatus.CANCELLED;
+    }
+
+    public Long getStoreId() {
+        return store.getId();
+    }
+
+    public String getChannelValue() {
+        return channel.getValue();
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaitingStatus.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaitingStatus.java
@@ -7,15 +7,16 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public enum StoreWaitingChannel {
+public enum StoreWaitingStatus {
 
-    IN_PERSON("IN_PERSON"),
-    ONLINE("ONLINE")
+    WAITING("WAITING"),
+    SEATED("SEATED"),
+    CANCELLED("CANCELLED")
     ;
 
     private final String value;
 
-    public static StoreWaitingChannel of(String value) {
+    public static StoreWaitingStatus of(String value) {
         try {
             return valueOf(value);
         } catch (IllegalArgumentException e) {

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
@@ -1,17 +1,23 @@
 package im.fooding.core.model.waiting;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.store.Store;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
-// todo: Store 객체 추가
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,9 +28,9 @@ public class WaitingUser extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
 
     private String name;
 
@@ -46,18 +52,23 @@ public class WaitingUser extends BaseEntity {
     @Column(nullable = false)
     private int count;
 
-//    @Builder
-//    public WaitingUser(Store store, String name, String phoneNumber, boolean termsAgreed, boolean privacyPolicyAgreed, boolean thirdPartyAgreed, boolean marketingConsent) {
-//        this.name = name;
-//        this.phoneNumber = phoneNumber;
-//        this.termsAgreed = termsAgreed;
-//        this.privacyPolicyAgreed = privacyPolicyAgreed;
-//        this.thirdPartyAgreed = thirdPartyAgreed;
-//        this.marketingConsent = marketingConsent;
-//        this.count = 0;
-//    }
+    @Builder
+    public WaitingUser(Store store, String name, String phoneNumber, boolean termsAgreed, boolean privacyPolicyAgreed, boolean thirdPartyAgreed, boolean marketingConsent) {
+        this.store = store;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.termsAgreed = termsAgreed;
+        this.privacyPolicyAgreed = privacyPolicyAgreed;
+        this.thirdPartyAgreed = thirdPartyAgreed;
+        this.marketingConsent = marketingConsent;
+        this.count = 0;
+    }
 
     public void visitStore() {
         count++;
+    }
+
+    public Long getStoreId() {
+        return store.getId();
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepository.java
@@ -1,0 +1,11 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QStoreWaitingRepository {
+
+    Page<StoreWaiting> findAllByStoreIdAndStatus(long storeId, StoreWaitingStatus status, Pageable pageable);
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/QStoreWaitingRepositoryImpl.java
@@ -1,0 +1,44 @@
+package im.fooding.core.repository.waiting;
+
+import static im.fooding.core.model.waiting.QStoreWaiting.storeWaiting;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class QStoreWaitingRepositoryImpl implements QStoreWaitingRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Page<StoreWaiting> findAllByStoreIdAndStatus(long storeId, StoreWaitingStatus status, Pageable pageable) {
+        List<StoreWaiting> results = query
+                .select(storeWaiting)
+                .from(storeWaiting)
+                .where(
+                        storeWaiting.store.id.eq(storeId),
+                        storeWaiting.status.eq(status)
+                )
+                .orderBy(storeWaiting.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<StoreWaiting> countQuery = query
+                .select(storeWaiting)
+                .from(storeWaiting)
+                .where(
+                        storeWaiting.store.id.eq(storeId),
+                        storeWaiting.status.eq(status)
+                );
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchCount);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.store.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreWaitingRepository extends JpaRepository<StoreWaiting, Long>, QStoreWaitingRepository {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingUserRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingUserRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.WaitingUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingUserRepository extends JpaRepository<WaitingUser, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -1,0 +1,26 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingStatus;
+import im.fooding.core.repository.waiting.StoreWaitingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class StoreWaitingService {
+
+    private final StoreWaitingRepository storeWaitingRepository;
+
+    public Page<StoreWaiting> getAllByStoreIdAndStatus(long storeId, String statusValue, Pageable pageable) {
+        StoreWaitingStatus status = StoreWaitingStatus.of(statusValue);
+
+        return storeWaitingRepository.findAllByStoreIdAndStatus(storeId, status, pageable);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
@@ -1,0 +1,102 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.TestConfig;
+import im.fooding.core.common.BasicSearch;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.StoreWaitingStatus;
+import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.waiting.StoreRepository;
+import im.fooding.core.repository.waiting.StoreWaitingRepository;
+import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.StoreDummy;
+import im.fooding.core.support.dummy.WaitingUserDummy;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+@TestConstructor(autowireMode = AutowireMode.ALL)
+@RequiredArgsConstructor
+class StoreWaitingServiceTest extends TestConfig {
+
+    private final StoreWaitingService storeWaitingService;
+    private final StoreWaitingRepository storeWaitingRepository;
+    private final WaitingUserRepository waitingUserRepository;
+    private final StoreRepository storeRepository;
+
+    @AfterEach
+    void tearDown() {
+        storeWaitingRepository.deleteAll();
+        waitingUserRepository.deleteAll();
+        storeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("가게 id로 특정 상태의 가게의 웨이팅을 모두 가져올 수 있다.")
+    void  get_all_store_waiting_with_specific_status() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser waitingUser = waitingUserRepository.save(WaitingUserDummy.create(store));
+
+        StoreWaiting storeWaiting = StoreWaiting.builder()
+                .user(waitingUser)
+                .store(store)
+                .callNumber(1)
+                .channel(StoreWaitingChannel.IN_PERSON)
+                .infantChairCount(1)
+                .infantCount(1)
+                .adultCount(1)
+                .build();
+
+        StoreWaiting cancledStoreWaiting = StoreWaiting.builder()
+                .user(waitingUser)
+                .store(store)
+                .callNumber(2)
+                .channel(StoreWaitingChannel.IN_PERSON)
+                .infantChairCount(1)
+                .infantCount(1)
+                .adultCount(1)
+                .build();
+        cancledStoreWaiting.cancel();
+
+        storeWaitingRepository.save(storeWaiting);
+        storeWaitingRepository.save(cancledStoreWaiting);
+
+        BasicSearch search = new BasicSearch();
+
+        // when
+        Page<StoreWaiting> waitingStoreWaitings = storeWaitingService.getAllByStoreIdAndStatus(
+                store.getId(),
+                StoreWaitingStatus.WAITING.getValue(),
+                search.getPageable()
+        );
+        Page<StoreWaiting> cancledStoreWaitings = storeWaitingService.getAllByStoreIdAndStatus(
+                store.getId(),
+                StoreWaitingStatus.CANCELLED.getValue(),
+                search.getPageable()
+        );
+
+        // then
+        StoreWaitingStatus waitingStoreWaitingStatus = waitingStoreWaitings.getContent()
+                .get(0)
+                .getStatus();
+        StoreWaitingStatus cancledStoreWaitingStatus = cancledStoreWaitings.getContent()
+                .get(0)
+                .getStatus();
+
+        Assertions.assertThat(waitingStoreWaitings)
+                .hasSize(1);
+        Assertions.assertThat(waitingStoreWaitingStatus)
+                .isEqualTo(StoreWaitingStatus.WAITING);
+        Assertions.assertThat(cancledStoreWaitings)
+                .hasSize(1);
+        Assertions.assertThat(cancledStoreWaitingStatus)
+                .isEqualTo(StoreWaitingStatus.CANCELLED);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
@@ -1,0 +1,24 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+
+public class StoreDummy {
+
+    public static Store create() {
+        return Store.builder()
+                .name("name")
+                .city("city")
+                .address("address")
+                .category("category")
+                .description("description")
+                .contactNumber("01012345678")
+                .priceCategory("priceCategory")
+                .eventDescription("eventDescription")
+                .direction("direction")
+                .information("information")
+                .isParkingAvailable(true)
+                .isNewOpen(true)
+                .isTakeOut(true)
+                .build();
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingUserDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingUserDummy.java
@@ -1,0 +1,19 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingUser;
+
+public class WaitingUserDummy {
+
+    public static WaitingUser create(Store store) {
+        return WaitingUser.builder()
+                .store(store)
+                .name("name")
+                .phoneNumber("01012345678")
+                .termsAgreed(true)
+                .privacyPolicyAgreed(true)
+                .thirdPartyAgreed(true)
+                .marketingConsent(true)
+                .build();
+    }
+}


### PR DESCRIPTION
### 관련 티켓
[[App] Wating 목록 조회 API 개발](https://www.notion.so/benkang/App-Wating-API-1ce83feabad380159c34d8adb663799c?pvs=4)

## 주요 변경 사항
### api
- 웨이팅 컨트롤러
  - 웨이팅 목록 조회 end-point 추가
- 웨이팅 애플리케이션 서비스
  - 가게 id와 상태를 이용한 조회 메서드 추가(listByStoreIdAndStatus 메서드)

### core
- 가게 웨이팅 서비스
  - 가게 id와 상태를 이용한 조회 기능 추가 (getAllByStoreIdAndStatus 메서드)
- 웨이팅 유저 서비스
  - 웨이팅 유저 조회 or 등록 기능 추가 (getOrElseRegister 메서드)
- 가게 도메인
  - 웨이팅 상태 변수 추가 (enum)
  - 상태 변경 메서드 추가 (seat, cancel)
- 관련 테스트 추가

### 수동 테스트
- config 파일 코드를 잠시 permitAll()로 변경하여 Postman 이용하여 테스트 했습니다.