### PR TITLE
 [BE-16] Menu 도메인 모델링 

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/model/menu/Menu.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/Menu.java
@@ -1,0 +1,84 @@
+package im.fooding.core.model.menu;
+
+import im.fooding.core.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class Menu extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private BigDecimal price;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "is_signature")
+    private boolean isSignature;
+
+    @Builder
+    private Menu(
+            String name,
+            BigDecimal price,
+            String description,
+            String imageUrl,
+            int sortOrder,
+            boolean isSignature
+    ) {
+        this.name = name;
+        this.price = price;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+        this.isSignature = isSignature;
+    }
+
+    private void updateName(String name) {
+        this.name = name;
+    }
+
+    private void updatePrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    private void updateDescription(String description) {
+        this.description = description;
+    }
+
+    private void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    private void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    private void updateIsSignature(boolean isSignature) {
+        this.isSignature = isSignature;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/menu/MenuBoard.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/MenuBoard.java
@@ -1,0 +1,55 @@
+package im.fooding.core.model.menu;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class MenuBoard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "menu_id",
+            nullable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    private Menu menu;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Builder
+    private MenuBoard(Menu menu, String title, String imageUrl) {
+        this.menu = menu;
+        this.title = title;
+        this.imageUrl = imageUrl;
+    }
+
+    public void update(Menu menu, String title, String imageUrl) {
+        this.menu = menu;
+        this.title = title;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/menu/MenuCategory.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/MenuCategory.java
@@ -1,0 +1,61 @@
+package im.fooding.core.model.menu;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class MenuCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "menu_id",
+            nullable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    private Menu menu;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Builder
+    private MenuCategory(Menu menu, String name, String description, int sortOrder) {
+        this.menu = menu;
+        this.name = name;
+        this.description = description;
+        this.sortOrder = sortOrder;
+    }
+
+    public void update(Menu menu, String name, String description, int sortOrder) {
+        this.menu = menu;
+        this.name = name;
+        this.description = description;
+        this.sortOrder = sortOrder;
+    }
+
+}


### PR DESCRIPTION
## 관련 티켓
[[CEO] Menu 도메인 모델링](https://www.notion.so/benkang/Menu-1cc83feabad380919e58ebfbeab5be53?pvs=4)

* 현재 티켓 ID에 맞게 브랜치 생성 후 작업하다가 티켓 ID가 겹치는 상황을 발견했습니다.

<img width="258" alt="image" src="https://github.com/user-attachments/assets/f82e4c58-18b5-4373-bb09-785a6759d6f5" />

![image](https://github.com/user-attachments/assets/5aec23d6-780a-4b3a-a1d4-d9ffe08aa649)

## 주요 변경 사항

* Menu : 메뉴판 도메인
* MenuCategory : 메뉴판 카테고리를 위한 도메인
* MenuBoard : 메뉴판 사진을 위한 도메인

## 리뷰 사항

* 현재 각 카테고리와 메뉴에 대해 정렬이 필요하여 필드를 추가하였습니다. 구현 방식에 따라 바뀌겠지만 해당 필드는 1..5...7 과 같이 각 값 사이의 여유를 두는 식으로 고려하였습니다. 이 부분에 대해 어떤 방식이 좋은지 코멘트 부탁드리겠습니다.