### PR TITLE
[BE-23] 웨이팅 상세 조회 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
@@ -1,0 +1,31 @@
+package im.fooding.app.controller.waiting;
+
+import im.fooding.app.dto.response.waiting.AppWaitingDetailsResponse;
+import im.fooding.app.service.waiting.AppWaitingApplicationService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/app/waitings")
+@Tag(name = "AppWaitingController", description = "웨이팅 관리 컨트롤러")
+@Slf4j
+public class AppWaitingController {
+
+    private final AppWaitingApplicationService appWaitingApplicationService;
+
+    @GetMapping("/{id}")
+    public ApiResult<AppWaitingDetailsResponse> details(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long id
+    ) {
+        return ApiResult.ok(appWaitingApplicationService.details(id));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/AppWaitingDetailsResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/AppWaitingDetailsResponse.java
@@ -1,0 +1,23 @@
+package im.fooding.app.dto.response.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.WaitingLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AppWaitingDetailsResponse(
+        @Schema(description = "웨이팅 정보")
+        WaitingResponse waiting,
+
+        @Schema
+        List<WaitingLogResponse> waitingLogs
+) {
+    public static AppWaitingDetailsResponse of(StoreWaiting waiting, List<WaitingLog> waitingLogs) {
+        WaitingResponse waitingResponse = WaitingResponse.from(waiting);
+        List<WaitingLogResponse> waitingLogResponses = waitingLogs.stream()
+                .map(WaitingLogResponse::from)
+                .toList();
+
+        return new AppWaitingDetailsResponse(waitingResponse, waitingLogResponses);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingLogResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingLogResponse.java
@@ -1,0 +1,19 @@
+package im.fooding.app.dto.response.waiting;
+
+import im.fooding.core.model.waiting.WaitingLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WaitingLogResponse(
+        @Schema(description = "id", example = "1")
+        long id,
+
+        @Schema(description = "변동 사항", example = "WAITING_REGISTRATION")
+        String type
+) {
+    public static WaitingLogResponse from(WaitingLog waitingLog) {
+        return new WaitingLogResponse(
+                waitingLog.getId(),
+                waitingLog.getTypeValue()
+        );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingResponse.java
@@ -1,0 +1,48 @@
+package im.fooding.app.dto.response.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WaitingResponse(
+        @Schema(description = "id", example = "1")
+        long id,
+
+        @Schema(description = "가게 id", example = "1")
+        long storeId,
+
+        @Schema(description = "유저 정보")
+        WaitingUserResponse user,
+
+        @Schema(description = "호출 번호", example = "1")
+        int callNumber,
+
+        @Schema(description = "등록 수단", example = "IN_PERSON")
+        String channel,
+
+        @Schema(description = "필요한 유아용 의자 개수", example = "1")
+        int infantChairCount,
+
+        @Schema(description = "유아 입장 인원수", example = "1")
+        int infantCount,
+
+        @Schema(description = "성인 입장 인원수", example = "1")
+        int adultCount,
+
+        @Schema(description = "메모", example = "this is memo.")
+        String memo
+) {
+
+    public static WaitingResponse from(StoreWaiting storeWaiting) {
+        return new WaitingResponse(
+                storeWaiting.getId(),
+                storeWaiting.getStoreId(),
+                WaitingUserResponse.from(storeWaiting.getUser()),
+                storeWaiting.getCallNumber(),
+                storeWaiting.getChannelValue(),
+                storeWaiting.getInfantChairCount(),
+                storeWaiting.getInfantCount(),
+                storeWaiting.getAdultCount(),
+                storeWaiting.getMemo()
+        );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingUserResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingUserResponse.java
@@ -1,0 +1,31 @@
+package im.fooding.app.dto.response.waiting;
+
+import im.fooding.core.model.waiting.WaitingUser;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WaitingUserResponse(
+        @Schema(description = "id", example = "1")
+        long id,
+
+        @Schema(description = "가게 id", example = "1")
+        long storeId,
+
+        @Schema(description = "이름", example = "홍길동")
+        String name,
+
+        @Schema(description = "전화번호", example = "01012345678")
+        String phoneNumber,
+
+        @Schema(description = "방문 횟수", example = "1")
+        int count
+) {
+    public static WaitingUserResponse from(WaitingUser waitingUser) {
+        return new WaitingUserResponse(
+                waitingUser.getId(),
+                waitingUser.getStoreId(),
+                waitingUser.getName(),
+                waitingUser.getPhoneNumber(),
+                waitingUser.getCount()
+        );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
@@ -1,0 +1,32 @@
+package im.fooding.app.service.waiting;
+
+import im.fooding.app.dto.response.waiting.AppWaitingDetailsResponse;
+import im.fooding.core.dto.request.waiting.WaitingLogFilter;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.WaitingLog;
+import im.fooding.core.service.waiting.StoreWaitingService;
+import im.fooding.core.service.waiting.WaitingLogService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class AppWaitingApplicationService {
+
+    private final StoreWaitingService storeWaitingService;
+    private final WaitingLogService waitingLogService;
+
+    public AppWaitingDetailsResponse details(long id) {
+        StoreWaiting storeWaiting = storeWaitingService.getStoreById(id);
+
+        WaitingLogFilter waitingLogFilter = new WaitingLogFilter(storeWaiting.getId(), null);
+        List<WaitingLog> waitingLogs = waitingLogService.list(waitingLogFilter);
+
+        return AppWaitingDetailsResponse.of(storeWaiting, waitingLogs);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/WaitingLogFilter.java
+++ b/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/WaitingLogFilter.java
@@ -1,0 +1,9 @@
+package im.fooding.core.dto.request.waiting;
+
+import im.fooding.core.model.waiting.WaitingLogType;
+
+public record WaitingLogFilter(
+    Long storeWaitingId,
+    WaitingLogType type
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -27,7 +27,11 @@ public enum ErrorCode {
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "1003", "이미 가입된 닉네임입니다."),
     UNSUPPORTED_SOCIAL(HttpStatus.BAD_REQUEST, "1004", "지원하지 않는 소셜로그인 입니다."),
     EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "1005", "이메일 제공 동의가 필요합니다."),
+
+    // 웨이팅
+    STORE_WAITING_NOT_FOUND(HttpStatus.BAD_REQUEST, "2000", "등록된 가게 웨이팅이 없습니다."),
     ;
+
     private final HttpStatus status;
 
     private final String code;

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -1,6 +1,7 @@
 package im.fooding.core.model.waiting;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.store.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -14,11 +15,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
-// todo: Store 객체 추가
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,9 +31,9 @@ public class StoreWaiting extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "waiting_user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -57,19 +58,27 @@ public class StoreWaiting extends BaseEntity {
     @Column(name = "memo", nullable = false)
     private String memo;
 
-//    @Builder
-//    public StoreWaiting(WaitingUser user, Store store, int callNumber, WaitingChannel channel, int infantChairCount, int infantCount, int adultCount) {
-//        this.user = user;
-//        this.store = sotre;
-//        this.callNumber = callNumber;
-//        this.channel = channel;
-//        this.infantChairCount = infantChairCount;
-//        this.infantCount = infantCount;
-//        this.adultCount = adultCount;
-//        this.memo = "";
-//    }
+    @Builder
+    public StoreWaiting(WaitingUser user, Store store, int callNumber, StoreWaitingChannel channel, int infantChairCount, int infantCount, int adultCount) {
+        this.user = user;
+        this.store = store;
+        this.callNumber = callNumber;
+        this.channel = channel;
+        this.infantChairCount = infantChairCount;
+        this.infantCount = infantCount;
+        this.adultCount = adultCount;
+        this.memo = "";
+    }
 
     public void updateMemo(String memo) {
         this.memo = memo;
+    }
+
+    public Long getStoreId() {
+        return store.getId();
+    }
+
+    public String getChannelValue() {
+        return channel.getValue();
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaitingChannel.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaitingChannel.java
@@ -1,7 +1,25 @@
 package im.fooding.core.model.waiting;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum StoreWaitingChannel {
-    IN_PERSON,
-    ONLINE
+
+    IN_PERSON("IN_PERSON"),
+    ONLINE("ONLINE")
     ;
-}
+
+    private final String value;
+
+    public static StoreWaitingChannel of(String value) {
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ErrorCode.METHOD_ARGUMENT_NOT_VALID);
+        }
+    }
+    }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingLog.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingLog.java
@@ -40,4 +40,8 @@ public class WaitingLog extends BaseEntity {
         this.storeWaiting = storeWaiting;
         this.type = type;
     }
+
+    public String getTypeValue() {
+        return type.getValue();
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingLogType.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingLogType.java
@@ -1,7 +1,14 @@
 package im.fooding.core.model.waiting;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum WaitingLogType {
-    WAITING_REGISTRATION,
-    ENTRY
+    WAITING_REGISTRATION("WAITING_REGISTRATION"),
+    ENTRY("ENTRY")
     ;
+
+    private final String value;
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
@@ -1,12 +1,19 @@
 package im.fooding.core.model.waiting;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.store.Store;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
@@ -22,9 +29,9 @@ public class WaitingUser extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-//    private Store store;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
 
     private String name;
 
@@ -46,18 +53,23 @@ public class WaitingUser extends BaseEntity {
     @Column(nullable = false)
     private int count;
 
-//    @Builder
-//    public WaitingUser(Store store, String name, String phoneNumber, boolean termsAgreed, boolean privacyPolicyAgreed, boolean thirdPartyAgreed, boolean marketingConsent) {
-//        this.name = name;
-//        this.phoneNumber = phoneNumber;
-//        this.termsAgreed = termsAgreed;
-//        this.privacyPolicyAgreed = privacyPolicyAgreed;
-//        this.thirdPartyAgreed = thirdPartyAgreed;
-//        this.marketingConsent = marketingConsent;
-//        this.count = 0;
-//    }
+    @Builder
+    public WaitingUser(Store store, String name, String phoneNumber, boolean termsAgreed, boolean privacyPolicyAgreed, boolean thirdPartyAgreed, boolean marketingConsent) {
+        this.store = store;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.termsAgreed = termsAgreed;
+        this.privacyPolicyAgreed = privacyPolicyAgreed;
+        this.thirdPartyAgreed = thirdPartyAgreed;
+        this.marketingConsent = marketingConsent;
+        this.count = 0;
+    }
 
     public void visitStore() {
         count++;
+    }
+
+    public Long getStoreId() {
+        return store.getId();
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/QWaitingLogRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/QWaitingLogRepository.java
@@ -1,0 +1,10 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.dto.request.waiting.WaitingLogFilter;
+import im.fooding.core.model.waiting.WaitingLog;
+import java.util.List;
+
+public interface QWaitingLogRepository {
+
+    List<WaitingLog> findAllWithFilter(WaitingLogFilter filter);
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/QWaitingLogRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/QWaitingLogRepositoryImpl.java
@@ -1,0 +1,39 @@
+package im.fooding.core.repository.waiting;
+
+import static im.fooding.core.model.waiting.QWaitingLog.waitingLog;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.dto.request.waiting.WaitingLogFilter;
+import im.fooding.core.model.waiting.WaitingLog;
+import im.fooding.core.model.waiting.WaitingLogType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class QWaitingLogRepositoryImpl implements QWaitingLogRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<WaitingLog> findAllWithFilter(WaitingLogFilter filter) {
+        return query
+                .select(waitingLog)
+                .from(waitingLog)
+                .where(
+                        storeWaitingIdEq(filter.storeWaitingId()),
+                        waitingLogEq(filter.type())
+                )
+                .orderBy(waitingLog.id.asc())
+                .fetch();
+    }
+
+    private BooleanExpression storeWaitingIdEq(Long storeWaitingId) {
+        return storeWaitingId != null ? waitingLog.storeWaiting.id.eq(storeWaitingId) : null;
+    }
+
+    private Predicate waitingLogEq(WaitingLogType type) {
+        return type != null ? waitingLog.type.eq(type) : null;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.store.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreWaitingRepository extends JpaRepository<StoreWaiting, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingLogRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingLogRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.WaitingLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingLogRepository extends JpaRepository<WaitingLog, Long>, QWaitingLogRepository {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingUserRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingUserRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.WaitingUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingUserRepository extends JpaRepository<WaitingUser, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -1,0 +1,24 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.repository.waiting.StoreWaitingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class StoreWaitingService {
+
+    private final StoreWaitingRepository storeWaitingRepository;
+
+    public StoreWaiting getStoreById(long id) {
+        return storeWaitingRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.STORE_WAITING_NOT_FOUND));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingLogService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingLogService.java
@@ -1,0 +1,23 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.dto.request.waiting.WaitingLogFilter;
+import im.fooding.core.model.waiting.WaitingLog;
+import im.fooding.core.repository.waiting.WaitingLogRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class WaitingLogService {
+
+    private final WaitingLogRepository waitingLogRepository;
+
+    public List<WaitingLog> list(WaitingLogFilter filter) {
+        return waitingLogRepository.findAllWithFilter(filter);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingLogServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingLogServiceTest.java
@@ -1,0 +1,64 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.TestConfig;
+import im.fooding.core.dto.request.waiting.WaitingLogFilter;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.WaitingLog;
+import im.fooding.core.model.waiting.WaitingLogType;
+import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.waiting.StoreRepository;
+import im.fooding.core.repository.waiting.StoreWaitingRepository;
+import im.fooding.core.repository.waiting.WaitingLogRepository;
+import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.StoreDummy;
+import im.fooding.core.support.dummy.StoreWaitingDummy;
+import im.fooding.core.support.dummy.WaitingUserDummy;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+
+@TestConstructor(autowireMode = AutowireMode.ALL)
+@RequiredArgsConstructor
+class WaitingLogServiceTest extends TestConfig {
+
+    private final WaitingLogService waitingLogService;
+    private final WaitingLogRepository waitingLogRepository;
+    private final WaitingUserRepository waitingUserRepository;
+    private final StoreWaitingRepository storeWaitingRepository;
+    private final StoreRepository storeRepository;
+
+    @AfterEach
+    void tearDown() {
+        waitingLogRepository.deleteAll();
+        waitingUserRepository.deleteAll();
+        storeWaitingRepository.deleteAll();
+        storeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("특정 가게 웨이팅 관련 로그를 모두 조회할 수 있다.")
+    public void get_all_waiting_logs_for_specific_store() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
+        StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
+
+        waitingLogRepository.save(new WaitingLog(storeWaiting, WaitingLogType.WAITING_REGISTRATION));
+        waitingLogRepository.save(new WaitingLog(storeWaiting, WaitingLogType.ENTRY));
+
+        // when
+        WaitingLogFilter filter = new WaitingLogFilter(storeWaiting.getId(), null);
+        List<WaitingLog> allByStoreWaitingId = waitingLogService.list(filter);
+
+        // then
+        Assertions.assertThat(allByStoreWaitingId)
+                .hasSize(2);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
@@ -1,0 +1,24 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+
+public class StoreDummy {
+
+    public static Store create() {
+        return Store.builder()
+                .name("name")
+                .city("city")
+                .address("address")
+                .category("category")
+                .description("description")
+                .contactNumber("01012345678")
+                .priceCategory("priceCategory")
+                .eventDescription("eventDescription")
+                .direction("direction")
+                .information("information")
+                .isParkingAvailable(true)
+                .isNewOpen(true)
+                .isTakeOut(true)
+                .build();
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreWaitingDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreWaitingDummy.java
@@ -1,0 +1,21 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.WaitingUser;
+
+public class StoreWaitingDummy {
+
+    public static StoreWaiting create(WaitingUser user, Store store) {
+        return StoreWaiting.builder()
+                .user(user)
+                .store(store)
+                .callNumber(1)
+                .channel(StoreWaitingChannel.IN_PERSON)
+                .infantChairCount(1)
+                .infantCount(1)
+                .adultCount(1)
+                .build();
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingUserDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingUserDummy.java
@@ -1,0 +1,19 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingUser;
+
+public class WaitingUserDummy {
+
+    public static WaitingUser create(Store store) {
+        return WaitingUser.builder()
+                .store(store)
+                .name("name")
+                .phoneNumber("01012345678")
+                .termsAgreed(true)
+                .privacyPolicyAgreed(true)
+                .thirdPartyAgreed(true)
+                .marketingConsent(true)
+                .build();
+    }
+}


### PR DESCRIPTION
### api
- 웨이팅 컨트롤러
  - 웨이팅 상세 조회 end-point 추가
- 웨이팅 애플리케이션 서비스
  - 웨이팅 상세 조회 기능 추가

### core
- 가게 웨이팅 서비스
  - id를 통한 store 조회 기능 추가
- 웨이팅 로그 서비스
  - 웨이팅 로그 리스트 조회 기능 추가