### PR TITLE
[BE-22] Admin Notification CRUD API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/notification/AdminNotificationController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/notification/AdminNotificationController.java
@@ -1,0 +1,60 @@
+package im.fooding.app.controller.admin.notification;
+
+import im.fooding.app.dto.request.admin.notification.AdminCreateNotificationRequest;
+import im.fooding.app.dto.request.admin.notification.AdminUpdateNotificationRequest;
+import im.fooding.app.dto.response.admin.notification.AdminNotificationResponse;
+import im.fooding.app.service.admin.notification.AdminNotificationApplicationService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/notifications")
+@Tag(name = "AdminNotificationController", description = "관리자 알림 컨트롤러")
+@Slf4j
+public class AdminNotificationController {
+
+    private final AdminNotificationApplicationService adminNotificationApplicationService;
+
+    @GetMapping
+    @Operation(summary = "알림 전체 조회")
+    public ApiResult<List<AdminNotificationResponse>> findAll(){
+      List<AdminNotificationResponse> notifications = adminNotificationApplicationService.getAllNotifications();
+      return ApiResult.ok(notifications);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "알림 상세 조회")
+    public ApiResult<AdminNotificationResponse> findById(@PathVariable Long id) {
+      AdminNotificationResponse response = adminNotificationApplicationService.getNotification(id);
+      return ApiResult.ok(response);
+    }
+
+    @PostMapping
+    @Operation(summary = "알림 생성")
+    public ApiResult<Long> create(@RequestBody @Valid AdminCreateNotificationRequest request) {
+      Long id = adminNotificationApplicationService.createNotification(request);
+      return ApiResult.ok(id);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "알림 수정")
+    public ApiResult<Void> update(@PathVariable Long id, @RequestBody @Valid AdminUpdateNotificationRequest request) {
+    adminNotificationApplicationService.updateNotification(id,request);
+      return ApiResult.ok();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "알림 삭제")
+    public ApiResult<Void> delete(@PathVariable Long id) {
+      adminNotificationApplicationService.deleteNotification(id);
+        return ApiResult.ok();
+      }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/notification/AdminCreateNotificationRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/notification/AdminCreateNotificationRequest.java
@@ -1,0 +1,40 @@
+package im.fooding.app.dto.request.admin.notification;
+
+import im.fooding.core.model.notification.NotificationChannel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class AdminCreateNotificationRequest {
+    @NotBlank(message = "발신자를 입력해주세요.")
+    @Schema(description = "알림 발신자", example = "system@example.com")
+    private String source;
+
+    @NotEmpty(message = "수신자를 한 명 이상 입력해주세요.")
+    @Schema(description = "알림 수신자 목록", example = "[\"user123\", \"user@example.com\"]")
+    private List<String> destinations;
+
+    @Size(max = 50, message = "제목은 50자 이내로 입력해주세요.")
+    @Schema(description = "알림 제목", example = "긴급 시스템 점검 안내")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    @Schema(description = "알림 내용", example = "오후 1시 시스템 점검 예정입니다.")
+    private String content;
+
+    @NotNull(message = "채널을 선택해주세요.")
+    @Schema(description = "알림 채널", example = "MAIL")
+    private NotificationChannel channel;
+
+    @Schema(description = "예약 발송 시간(옵션)", example = "2025-04-11 13:00:00")
+    private LocalDateTime scheduledAt;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/notification/AdminUpdateNotificationRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/notification/AdminUpdateNotificationRequest.java
@@ -1,0 +1,34 @@
+package im.fooding.app.dto.request.admin.notification;
+
+import im.fooding.core.model.notification.NotificationChannel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class AdminUpdateNotificationRequest {
+    @NotNull(message = "알림 번호를 입력해주세요.")
+    @Schema(description = "알림 ID", example = "1")
+    private Long id;
+
+    @Size(max = 50, message = "제목은 50자 이내로 입력해주세요.")
+    @Schema(description = "알림 제목", example = "긴급 시스템 점검 안내")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    @Schema(description = "알림 내용", example = "오후 1시 시스템 점검 예정입니다.")
+    private String content;
+
+    @NotNull(message = "채널을 선택해주세요.")
+    @Schema(description = "알림 채널", example = "MAIL")
+    private NotificationChannel channel;
+
+    @Schema(description = "예약 발송 시간", example = "2025-04-11 13:00:00")
+    private LocalDateTime scheduledAt;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/admin/notification/AdminNotificationResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/admin/notification/AdminNotificationResponse.java
@@ -1,0 +1,76 @@
+package im.fooding.app.dto.response.admin.notification;
+
+import im.fooding.core.model.notification.Notification;
+import im.fooding.core.model.notification.NotificationChannel;
+import im.fooding.core.model.notification.NotificationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class AdminNotificationResponse {
+    @Schema(description = "id", example = "1")
+    private long id;
+
+    @Schema(description = "알림 발신자", example = "system@example.com")
+    private String source;
+
+    @Schema(description = "알림 수신자", example = "user@example.com")
+    private List<String> destinations;
+
+    @Schema(description = "알림 제목", example = "긴급 시스템 점검 안내")
+    private String title;
+
+    @Schema(description = "알림 내용", example = "오후 1시 시스템 점검 예정입니다.")
+    private String content;
+
+    @Schema(description = "알림 채널", example = "MAIL")
+    private NotificationChannel channel;
+
+    @Schema(description = "알림 상태", example = "PENDING")
+    private NotificationStatus status;
+
+    @Schema(description = "보낸 시간", example = "2025-04-11 13:00:00")
+    private LocalDateTime sentAt;
+
+    @Schema(description = "읽은 시간", example = "2025-04-11 14:00:00")
+    private LocalDateTime readAt;
+
+    @Schema(description = "예약 발송 시간", example = "2025-04-11 13:00:00")
+    private LocalDateTime scheduledAt;
+
+    @Builder
+    private AdminNotificationResponse(long id, String source, List<String> destinations, String title, String content, NotificationChannel channel, NotificationStatus status, LocalDateTime sentAt, LocalDateTime readAt, LocalDateTime scheduledAt ) {
+      this.id = id;
+      this.source = source;
+      this.destinations = destinations;
+      this.title = title;
+      this.content = content;
+      this.channel = channel;
+      this.status = status;
+      this.sentAt = sentAt;
+      this.readAt = readAt;
+      this.scheduledAt = scheduledAt;
+    }
+
+    public static AdminNotificationResponse of(Notification notification) {
+      return AdminNotificationResponse.builder()
+              .id(notification.getId())
+              .source(notification.getSource())
+              .destinations(Arrays.asList(notification.getDestination().split(",")))
+              .title(notification.getTitle())
+              .content(notification.getContent())
+              .channel(notification.getChannel())
+              .status(notification.getStatus())
+              .sentAt(notification.getSentAt())
+              .readAt(notification.getReadAt())
+              .scheduledAt(notification.getScheduledAt())
+              .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/notification/AdminNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/notification/AdminNotificationApplicationService.java
@@ -1,0 +1,73 @@
+package im.fooding.app.service.admin.notification;
+
+import im.fooding.app.dto.request.admin.notification.AdminCreateNotificationRequest;
+import im.fooding.app.dto.request.admin.notification.AdminUpdateNotificationRequest;
+import im.fooding.app.dto.response.admin.manager.AdminManagerResponse;
+import im.fooding.app.dto.response.admin.notification.AdminNotificationResponse;
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.notification.Notification;
+import im.fooding.core.model.notification.NotificationStatus;
+import im.fooding.core.service.notification.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class AdminNotificationApplicationService {
+
+    private final NotificationService notificationService;
+
+    // 알림 전체 조회
+    public List<AdminNotificationResponse> getAllNotifications() {
+      return notificationService.findAll().stream()
+              .map(AdminNotificationResponse::of)
+              .toList();
+    }
+
+    // 알림 상세 조회
+    public AdminNotificationResponse getNotification(Long id) {
+    Notification notification = notificationService.findById(id);
+    return AdminNotificationResponse.of(notification);
+    }
+
+    // 알림 생성
+    @Transactional
+    public Long createNotification(AdminCreateNotificationRequest request) {
+      String destinationString = String.join(",", request.getDestinations());
+
+      Notification notification = Notification.builder()
+              .source((request.getSource()))
+              .destination(destinationString)
+              .title(request.getTitle())
+              .content(request.getContent())
+              .channel(request.getChannel())
+              .build();
+
+      if (request.getScheduledAt() != null) {
+        notification.schedule(request.getScheduledAt()); // 예약 발송
+      } else {
+        notification.send(); // 즉시 발송
+      }
+
+      return notificationService.create(notification).getId();
+    }
+
+    // 알림 수정
+    @Transactional
+    public void updateNotification(Long id, AdminUpdateNotificationRequest request) {
+      notificationService.update(id, request.getTitle(), request.getContent(), request.getChannel(), request.getScheduledAt());
+    }
+
+    // 알림 삭제
+    @Transactional
+    public void deleteNotification(Long id) {
+      notificationService.delete(id);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -27,7 +27,10 @@ public enum ErrorCode {
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "1003", "이미 가입된 닉네임입니다."),
     UNSUPPORTED_SOCIAL(HttpStatus.BAD_REQUEST, "1004", "지원하지 않는 소셜로그인 입니다."),
     EMAIL_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "1005", "이메일 제공 동의가 필요합니다."),
-    ;
+
+    // 알림
+    NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "5000", "등록된 알림이 없습니다.");
+
     private final HttpStatus status;
 
     private final String code;

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/Notification.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/Notification.java
@@ -48,13 +48,22 @@ public class Notification extends BaseEntity {
 
     @Builder
     public Notification(String source, String destination,
-                        String title, String content, NotificationChannel channel, NotificationStatus status) {
+                        String title, String content, NotificationChannel channel, NotificationStatus status, LocalDateTime scheduledAt) {
       this.source = source;
       this.destination = destination;
       this.title = title;
       this.content = content;
       this.channel = channel;
       this.status = status;
+      this.scheduledAt = scheduledAt;
+    }
+
+    public void update(String title, String content, NotificationChannel channel, LocalDateTime scheduledAt) {
+      this.title = title;
+      this.content = content;
+      this.channel = channel;
+      this.scheduledAt = scheduledAt;
+      this.status = NotificationStatus.PENDING;
     }
 
     public void send() {

--- a/fooding-core/src/main/java/im/fooding/core/repository/notification/NotificationRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/notification/NotificationRepository.java
@@ -1,0 +1,9 @@
+package im.fooding.core.repository.notification;
+
+import im.fooding.core.model.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/notification/NotificationService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/notification/NotificationService.java
@@ -1,0 +1,54 @@
+package im.fooding.core.service.notification;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.notification.Notification;
+import im.fooding.core.model.notification.NotificationChannel;
+import im.fooding.core.repository.notification.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    // 알림 전체 조회
+    public List<Notification> findAll() {
+        return notificationRepository.findAll();
+    }
+
+    // 알림 상세 조회
+    public Notification findById(Long id) {
+        return notificationRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOTIFICATION_NOT_FOUND));
+    }
+
+    // 알림 생성
+    @Transactional
+    public Notification create(Notification notification) {
+        return notificationRepository.save(notification);
+    }
+
+    // 알림 수정
+    @Transactional
+    public void update(Long id, String title, String content, NotificationChannel channel, LocalDateTime scheduledAt) {
+        Notification notification = findById(id);
+        notification.update(title, content, channel, scheduledAt);
+    }
+
+    // 알림 삭제
+    @Transactional
+    public void delete(Long id) {
+        Notification notification = findById(id);
+        notificationRepository.delete(notification);
+    }
+}


### PR DESCRIPTION
[BE-22]

#### 🙆‍♀️티켓
[[ADMIN] Notification CRUD API 개발](https://www.notion.so/benkang/ADMIN-Notification-CRUD-API-1cd83feabad3809e991ed2895e82146a?pvs=4)

##

#### 🙆‍♀️상세 설명
[ API ]
`AdminCreateNotificationRequest` - 알림 생성 요청을 위한 DTO 
`AdminUpdateNotificationRequest` -  알림 수정 요청을 위한 DTO 
`AdminNotificationResponse` - 알림 응답을 위한 DTO 
`AdminNotificationApplicationService` - 알림 관련 비즈니스 로직을 처리하는 서비스
`AdminNotificationController` - 관리자가 접근하는 알림 컨트롤러


[ Core ]
`Notification` - 알림 도메인 엔티티 메서드 추가 및 일부 로직 수정
`NotificationRepository` - 알림 도메인 정보를 가져오기 위한 JPA 레포지토리 제작
`NotificationService`- `NotificationRepository`와 통신하는 서비스