### PR TITLE
[BE-17-2] 웨이팅 목록 조회 API 추가 (Pos)

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -1,0 +1,34 @@
+package im.fooding.app.controller.waiting;
+
+import im.fooding.app.service.waiting.PosWaitingApplicationService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import im.fooding.app.dto.request.waiting.WaitingListRequest;
+import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.core.common.PageResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pos/waitings")
+@Tag(name = "PosWaitingController", description = "웨이팅 관리 컨트롤러")
+@Slf4j
+public class PosWaitingController {
+
+    private final PosWaitingApplicationService posWaitingApplicationService;
+
+    @GetMapping("/{id}/requests")
+    @Operation(summary = "웨이팅 목록 조회")
+    ApiResult<PageResponse<WaitingResponse>> list(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long id,
+
+            @ModelAttribute WaitingListRequest request
+    ) {
+        return ApiResult.ok(posWaitingApplicationService.list(id, request));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
@@ -1,0 +1,51 @@
+package im.fooding.app.service.waiting;
+
+import im.fooding.app.dto.request.waiting.AppWaitingRegisterRequest;
+import im.fooding.app.dto.request.waiting.WaitingListRequest;
+import im.fooding.app.dto.response.waiting.AppWaitingRegisterResponse;
+import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
+import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
+import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.model.waiting.*;
+import im.fooding.core.service.waiting.StoreWaitingService;
+import im.fooding.core.service.waiting.WaitingLogService;
+import im.fooding.core.service.waiting.WaitingService;
+import im.fooding.core.service.waiting.WaitingUserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class PosWaitingApplicationService {
+
+    private final WaitingService waitingService;
+    private final StoreWaitingService storeWaitingService;
+
+    public PageResponse<WaitingResponse> list(long id, WaitingListRequest request) {
+
+        Waiting waiting = waitingService.getById(id);
+
+        StoreWaitingFilter storeWaitingFilter = StoreWaitingFilter.builder()
+                .storeId(waiting.getStore().getId())
+                .status(StoreWaitingStatus.of(request.status()))
+                .build();
+        Page<StoreWaiting> storeWaitings = storeWaitingService.list(storeWaitingFilter, request.pageable());
+
+        List<WaitingResponse> list = storeWaitings.getContent()
+                .stream()
+                .map(WaitingResponse::from)
+                .toList();
+
+        return PageResponse.of(list, PageInfo.of(storeWaitings));
+    }
+}


### PR DESCRIPTION
### 관련 티켓
[[App-관리] Waiting 목록 조회 API 개발](https://www.notion.so/benkang/App-Wating-API-1ca83feabad380c4ad56c76b025534d3?pvs=4)

## 주요 변경 사항
### api
- 웨이팅 컨트롤러(Pos)
  - 웨이팅 목록 조회 end-point 추가(Pos)
- 웨이팅 애플리케이션 서비스(Pos)
  - 가게 웨이팅 조회 메서드 추가(Pos)


같은 기능을 하는 #12 가 완료 상태여서 end-point 만 변경하여 구현했습니다.