### PR TITLE
[BE-26] 특정 웨이팅 로그 페이지 조회 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
@@ -2,8 +2,10 @@ package im.fooding.app.controller.waiting;
 
 import im.fooding.app.dto.request.waiting.AppWaitingRegisterRequest;
 import im.fooding.app.dto.response.waiting.AppWaitingRegisterResponse;
+import im.fooding.app.dto.response.waiting.WaitingLogResponse;
 import im.fooding.app.service.waiting.AppWaitingApplicationService;
 import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.BasicSearch;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,6 +48,17 @@ public class AppWaitingController {
             @PathVariable long requestId
     ) {
         return ApiResult.ok(appWaitingApplicationService.details(requestId));
+    }
+
+    @GetMapping("/requests/{requestId}/logs")
+    public ApiResult<PageResponse<WaitingLogResponse>> listLogs(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long requestId,
+
+            @Parameter(description = "검색 및 페이징 조건")
+            @ModelAttribute BasicSearch search
+    ) {
+        return ApiResult.ok(appWaitingApplicationService.listLogs(requestId, search));
     }
 
     @PostMapping("/{id}/requests")

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
@@ -96,7 +96,7 @@ public class AppWaitingApplicationService {
     }
 
     public PageResponse<WaitingLogResponse> listLogs(long requestId, BasicSearch search) {
-        Page<WaitingLog> logs = waitingLogService.list(requestId, search);
+        Page<WaitingLog> logs = waitingLogService.list(requestId, search.getPageable());
 
         List<WaitingLogResponse> list = logs.getContent()
                 .stream()

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
@@ -2,11 +2,14 @@ package im.fooding.app.service.waiting;
 
 import im.fooding.app.dto.request.waiting.AppWaitingRegisterRequest;
 import im.fooding.app.dto.response.waiting.AppWaitingRegisterResponse;
+import im.fooding.app.dto.response.waiting.WaitingLogResponse;
+import im.fooding.core.common.BasicSearch;
 import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
 import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.StoreWaitingChannel;
 import im.fooding.core.model.waiting.Waiting;
+import im.fooding.core.model.waiting.WaitingLog;
 import im.fooding.core.model.waiting.WaitingUser;
 import im.fooding.core.service.waiting.StoreWaitingService;
 import im.fooding.core.service.waiting.WaitingLogService;
@@ -90,5 +93,16 @@ public class AppWaitingApplicationService {
         waitingLogService.logRegister(storeWaiting);
 
         return new AppWaitingRegisterResponse(storeWaiting.getCallNumber());
+    }
+
+    public PageResponse<WaitingLogResponse> listLogs(long requestId, BasicSearch search) {
+        Page<WaitingLog> logs = waitingLogService.list(requestId, search);
+
+        List<WaitingLogResponse> list = logs.getContent()
+                .stream()
+                .map(WaitingLogResponse::from)
+                .toList();
+
+        return PageResponse.of(list, PageInfo.of(logs));
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingLogRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingLogRepository.java
@@ -1,7 +1,11 @@
 package im.fooding.core.repository.waiting;
 
 import im.fooding.core.model.waiting.WaitingLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WaitingLogRepository extends JpaRepository<WaitingLog, Long> {
+
+    Page<WaitingLog> findAllByStoreWaitingId(long id, Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingLogService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingLogService.java
@@ -1,10 +1,13 @@
 package im.fooding.core.service.waiting;
 
+import im.fooding.core.common.BasicSearch;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.WaitingLog;
 import im.fooding.core.repository.waiting.WaitingLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,5 +22,9 @@ public class WaitingLogService {
     @Transactional
     public WaitingLog logRegister(StoreWaiting storeWaiting) {
         return waitingLogRepository.save(new WaitingLog(storeWaiting));
+    }
+
+    public Page<WaitingLog> list(long storeWaitingId, Pageable pageable) {
+        return waitingLogRepository.findAllByStoreWaitingId(storeWaitingId, pageable);
     }
 }


### PR DESCRIPTION
## 관련 티켓
[[APP] 웨이팅 상세에서 로그는 분리](https://www.notion.so/benkang/APP-1d783feabad380378952e05781aba695?pvs=4)

# 주요 변경 사항

## api
- 특정 웨이팅 로그 페이지 조회 end-point 추가

## core
- 특정 웨이팅 로그 페이지 조회 기능 추가

### 테스트
- 로그 페이지 조회 성공 테스트 추가