### PR TITLE
[BE-39] 웨이팅 호출 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -31,4 +31,14 @@ public class PosWaitingController {
     ) {
         return ApiResult.ok(posWaitingApplicationService.list(id, request));
     }
+
+    @PostMapping("/requests/{requestId}/call")
+    @Operation(summary = "웨이팅 호출")
+    ApiResult<Void> call(
+            @Parameter(description = "가게 웨이팅 id", example = "1")
+            @PathVariable long requestId
+    ) {
+        posWaitingApplicationService.call(requestId);
+        return ApiResult.ok();
+    }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -30,6 +30,11 @@ public class UserNotificationApplicationService {
         slackClient.sendNotificationMessage(message);
     }
 
+    public void sendWaitingCallMessage(String store, int callNumber, int entryTimeLimit) {
+        String message = WaitingMessageBuilder.buildWaitingCallMessage(store, callNumber, entryTimeLimit);
+        slackClient.sendNotificationMessage(message);
+    }
+
     /**
      * 입장 메세지 발송(슬랙으로 대체) 예시 추후 삭제 요망
      *

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
@@ -1,19 +1,15 @@
 package im.fooding.app.service.waiting;
 
-import im.fooding.app.dto.request.waiting.AppWaitingRegisterRequest;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
-import im.fooding.app.dto.response.waiting.AppWaitingRegisterResponse;
 import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.app.service.user.notification.UserNotificationApplicationService;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
-import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
-import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
 import im.fooding.core.model.waiting.*;
 import im.fooding.core.service.waiting.StoreWaitingService;
-import im.fooding.core.service.waiting.WaitingLogService;
 import im.fooding.core.service.waiting.WaitingService;
-import im.fooding.core.service.waiting.WaitingUserService;
+import im.fooding.core.service.waiting.WaitingSettingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -28,8 +24,10 @@ import java.util.List;
 @Slf4j
 public class PosWaitingApplicationService {
 
+    private final UserNotificationApplicationService userNotificationApplicationService;
     private final WaitingService waitingService;
     private final StoreWaitingService storeWaitingService;
+    private final WaitingSettingService waitingSettingService;
 
     public PageResponse<WaitingResponse> list(long id, WaitingListRequest request) {
 
@@ -47,5 +45,18 @@ public class PosWaitingApplicationService {
                 .toList();
 
         return PageResponse.of(list, PageInfo.of(storeWaitings));
+    }
+
+    @Transactional
+    public void call(long requestId) {
+        WaitingSetting waitingSetting = waitingSettingService.getActiveSetting();
+
+        StoreWaiting storeWaiting = storeWaitingService.call(requestId);
+
+        userNotificationApplicationService.sendWaitingCallMessage(
+                storeWaiting.getStoreName(),
+                storeWaiting.getCallNumber(),
+                waitingSetting.getEntryTimeLimitMinutes()
+        );
     }
 }

--- a/fooding-api/src/main/resources/application-local.yml
+++ b/fooding-api/src/main/resources/application-local.yml
@@ -57,7 +57,7 @@ logging:
 
 webhook:
   slack:
-    url: https://hooks.slack.com/services/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
+    url: https://hooks.slack.com/services/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
 
 message:
   sender: 02-1234-5678

--- a/fooding-api/src/main/resources/application-prod.yml
+++ b/fooding-api/src/main/resources/application-prod.yml
@@ -56,7 +56,7 @@ logging:
 
 webhook:
   slack:
-    url: https://hooks.slack.com/services/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
+    url: https://hooks.slack.com/services/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
 
 message:
   sender: 02-1234-5678

--- a/fooding-api/src/main/resources/application-stage.yml
+++ b/fooding-api/src/main/resources/application-stage.yml
@@ -56,7 +56,7 @@ logging:
 
 webhook:
   slack:
-    url: https://hooks.slack.com/services/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
+    url: https://hooks.slack.com/services/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
 
 message:
   sender: 02-1234-5678

--- a/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         .requestMatchers("/user/**").hasAnyRole("USER")
                         .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                         .requestMatchers("/ceo/**").hasAnyRole("CEO")
-                        .anyRequest().permitAll());
+                        .anyRequest().authenticated());
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         .requestMatchers("/user/**").hasAnyRole("USER")
                         .requestMatchers("/admin/**").hasAnyRole("ADMIN")
                         .requestMatchers("/ceo/**").hasAnyRole("CEO")
-                        .anyRequest().authenticated());
+                        .anyRequest().permitAll());
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     WAITING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3000", "등록된 웨이팅 정보가 없습니다."),
     WAITING_NOT_OPENED(HttpStatus.BAD_REQUEST, "3001", "웨이팅이 오픈상태가 아닙니다."),
     STORE_WAITING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3002", "등록된 가게 웨이팅이 없습니다."),
-
+    STORE_WAITING_ILLEGAL_STATE_CALL(HttpStatus.BAD_REQUEST, "3003", "호출할 가능한 웨이팅 상태가 아닙니다."),
+    ACTIVE_WAITING_SETTING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3004", "활성화된 웨이팅 세팅이 없습니다."),
 
     // 디바이스
     DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "7000", "등록된 디바이스가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/global/util/WaitingMessageBuilder.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/util/WaitingMessageBuilder.java
@@ -24,6 +24,21 @@ public class WaitingMessageBuilder {
         return messageBuilder.toString();
     }
 
+    public static String buildWaitingCallMessage(String store, int callNumber, int entryTimeLimit) {
+        return """
+                Title
+                입장할 순서예요! 지금 매장에 입장해 주세요!
+                                
+                %d번 고객님, 기다려주셔서 감사해요!
+                %s에 입장해 주세요:)
+                                
+                직원에게 톡 사진을 보여주시면 순서대로 안내드릴게요!
+                                
+                %d분으로 입장 시간이 제한되어있어요. 방문이 취소될 수 있으니 시간 확인 부탁드려요!
+                """
+                .formatted(callNumber, store, entryTimeLimit);
+    }
+
     public static String buildEnterStoreMessage(String sender, String receiver, String store, String notice, int waitingNumber, int limitTime) {
         StringBuilder messageBuilder = new StringBuilder();
 

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -42,6 +42,9 @@ public class StoreWaiting extends BaseEntity {
     @Column(name = "call_number", nullable = false)
     private int callNumber;
 
+    @Column(name = "call_count", nullable = false)
+    private int callCount;
+
     @Column(name = "store_waiting_status", nullable = false)
     private StoreWaitingStatus status;
 
@@ -74,6 +77,7 @@ public class StoreWaiting extends BaseEntity {
         this.user = user;
         this.store = store;
         this.callNumber = callNumber;
+        this.callCount = 0;
         this.status = StoreWaitingStatus.WAITING;
         this.channel = channel;
         this.infantChairCount = infantChairCount;
@@ -100,5 +104,13 @@ public class StoreWaiting extends BaseEntity {
 
     public Long getStoreId() {
         return store.getId();
+    }
+
+    public String getStoreName() {
+        return store.getName();
+    }
+
+    public void call() {
+        callCount++;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingSetting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingSetting.java
@@ -38,6 +38,9 @@ public class WaitingSetting extends BaseEntity {
     @Column(nullable = false)
     private boolean isActive;
 
+    @Column(nullable = false)
+    private int entryTimeLimitMinutes;
+
     @Builder
     private WaitingSetting(
             Waiting waiting,
@@ -45,7 +48,8 @@ public class WaitingSetting extends BaseEntity {
             int minimumCapacity,
             int maximumCapacity,
             Integer estimatedWaitingTimeMinutes,
-            boolean isActive
+            boolean isActive,
+            int entryTimeLimitMinutes
     ) {
         this.waiting = waiting;
         this.label = label;
@@ -53,6 +57,7 @@ public class WaitingSetting extends BaseEntity {
         this.maximumCapacity = maximumCapacity;
         this.estimatedWaitingTimeMinutes = estimatedWaitingTimeMinutes;
         this.isActive = isActive;
+        this.entryTimeLimitMinutes = entryTimeLimitMinutes;
     }
 
     public void update(String label, int minimumCapacity, int maximumCapacity, Integer estimatedWaitingTimeMinutes) {

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingSettingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingSettingRepository.java
@@ -1,0 +1,10 @@
+package im.fooding.core.repository.waiting;
+
+import im.fooding.core.model.waiting.WaitingSetting;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WaitingSettingRepository extends JpaRepository<WaitingSetting, Long> {
+
+    Optional<WaitingSetting> findByIsActiveIsTrue();
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -5,6 +5,7 @@ import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.StoreWaitingStatus;
 import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingStatus;
 import im.fooding.core.repository.waiting.StoreWaitingRepository;
@@ -32,6 +33,17 @@ public class StoreWaitingService {
     public StoreWaiting getStoreWaiting(long id) {
         return storeWaitingRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ErrorCode.STORE_WAITING_NOT_FOUND));
+    }
+
+    @Transactional
+    public StoreWaiting call(long id) {
+        StoreWaiting storeWaiting = getStoreWaiting(id);
+        if (storeWaiting.getStatus() != StoreWaitingStatus.WAITING) {
+            throw new ApiException(ErrorCode.STORE_WAITING_ILLEGAL_STATE_CALL);
+        }
+        storeWaiting.call();
+
+        return storeWaiting;
     }
 
     @Transactional

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingSettingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingSettingService.java
@@ -1,0 +1,24 @@
+package im.fooding.core.service.waiting;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.waiting.WaitingSetting;
+import im.fooding.core.repository.waiting.WaitingSettingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class WaitingSettingService {
+
+    private final WaitingSettingRepository waitingSettingRepository;
+
+    public WaitingSetting getActiveSetting() {
+        return waitingSettingRepository.findByIsActiveIsTrue()
+                .orElseThrow(() -> new ApiException(ErrorCode.ACTIVE_WAITING_SETTING_NOT_FOUND));
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
@@ -212,4 +212,20 @@ class StoreWaitingServiceTest extends TestConfig {
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.WAITING_NOT_OPENED);
     }
+
+    @Test
+    @DisplayName("호출시 호출 횟수를 증가한다.")
+    public void testCall() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
+        StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
+
+        // when
+        storeWaitingService.call(storeWaiting.getId());
+
+        // then
+        Assertions.assertThat(storeWaiting.getCallCount())
+                .isEqualTo(1);
+    }
 }

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingSettingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingSettingServiceTest.java
@@ -1,0 +1,69 @@
+package im.fooding.core.service.waiting;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import im.fooding.core.TestConfig;
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.Waiting;
+import im.fooding.core.model.waiting.WaitingSetting;
+import im.fooding.core.repository.store.StoreRepository;
+import im.fooding.core.repository.waiting.WaitingRepository;
+import im.fooding.core.repository.waiting.WaitingSettingRepository;
+import im.fooding.core.support.dummy.StoreDummy;
+import im.fooding.core.support.dummy.WaitingDummy;
+import im.fooding.core.support.dummy.WaitingSettingDummy;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestConstructor;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class WaitingSettingServiceTest extends TestConfig {
+
+    private final WaitingSettingService waitingSettingService;
+    private final WaitingSettingRepository waitingSettingRepository;
+    private final WaitingRepository waitingRepository;
+    private final StoreRepository storeRepository;
+
+    @AfterEach
+    void tearDown() {
+        waitingSettingRepository.deleteAll();
+        waitingRepository.deleteAll();
+        storeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("활성화된 웨이팅 세팅을 조회할 수 있다.")
+    public void testGetActive() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        Waiting waiting = waitingRepository.save(WaitingDummy.create(store));
+        waitingSettingRepository.save(WaitingSettingDummy.create(waiting, true));
+
+        // when
+        WaitingSetting waitingSetting = waitingSettingService.getActiveSetting();
+
+        // then
+        Assertions.assertThat(waitingSetting.isActive())
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("활성화된 웨이팅 세팅이 존재하지 않는 경우 활성 웨이팅 세팅을 조회할 수 없다.")
+    public void testGetActive_fail_whenNotFoundActiveSetting() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        Waiting waiting = waitingRepository.save(WaitingDummy.create(store));
+        waitingSettingRepository.save(WaitingSettingDummy.create(waiting, false));
+
+        // when & then
+        ApiException e = assertThrows(ApiException.class, waitingSettingService::getActiveSetting);
+        Assertions.assertThat(e.getErrorCode())
+                .isEqualTo(ErrorCode.ACTIVE_WAITING_SETTING_NOT_FOUND);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingDummy.java
@@ -1,0 +1,12 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.Waiting;
+import im.fooding.core.model.waiting.WaitingStatus;
+
+public class WaitingDummy {
+
+    public static Waiting create(Store store) {
+        return new Waiting(store, WaitingStatus.WAITING_OPEN);
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingSettingDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/WaitingSettingDummy.java
@@ -1,0 +1,19 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.waiting.Waiting;
+import im.fooding.core.model.waiting.WaitingSetting;
+
+public class WaitingSettingDummy {
+
+    public static WaitingSetting create(Waiting waiting, boolean isActive) {
+        return WaitingSetting.builder()
+                .waiting(waiting)
+                .label("label")
+                .minimumCapacity(1)
+                .maximumCapacity(10)
+                .estimatedWaitingTimeMinutes(15)
+                .isActive(isActive)
+                .entryTimeLimitMinutes(5)
+                .build();
+    }
+}


### PR DESCRIPTION
## 관련 티켓
[[BE-39] 웨이팅 호출 API](https://www.notion.so/benkang/POS-API-1d783feabad38022998ef947f139a9d6?pvs=4)

## 주요 변경사항

### api
- 가게 웨이팅 호출 end-point 추가
- 가게 웨이팅 호출 로직 추가
- 가게 웨이팅 호출 메세지 생성 로직 추가

### core
- `WaitingSetting` entity
  - 호출 횟수 컬럼 추가
- 가게 웨이팅 호출 로직 추가

### 기타 사항
- slack webhook url 변경