### PR TITLE
[BE-27] [POS] 웨이팅 착석 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -31,4 +31,14 @@ public class PosWaitingController {
     ) {
         return ApiResult.ok(posWaitingApplicationService.list(id, request));
     }
+
+    @PostMapping("/requests/{requestId}/seat")
+    @Operation(summary = "웨이팅 착석")
+    ApiResult<Void> seat(
+            @Parameter(description = "가게 웨이팅 id", example = "1")
+            @PathVariable long requestId
+    ) {
+        posWaitingApplicationService.seat(requestId);
+        return ApiResult.ok();
+    }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
@@ -48,4 +48,9 @@ public class PosWaitingApplicationService {
 
         return PageResponse.of(list, PageInfo.of(storeWaitings));
     }
+
+    @Transactional
+    public void seat(long requestId) {
+        storeWaitingService.seat(requestId);
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
     WAITING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3000", "등록된 웨이팅 정보가 없습니다."),
     WAITING_NOT_OPENED(HttpStatus.BAD_REQUEST, "3001", "웨이팅이 오픈상태가 아닙니다."),
     STORE_WAITING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3002", "등록된 가게 웨이팅이 없습니다."),
-
+    STORE_WAITING_ILLEGAL_STATE_SEAT(HttpStatus.BAD_REQUEST, "3003", "착성 가능한 웨이팅 상태가 아닙니다."),
 
     // 디바이스
     DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "7000", "등록된 디바이스가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -43,6 +43,7 @@ public class StoreWaiting extends BaseEntity {
     private int callNumber;
 
     @Column(name = "store_waiting_status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private StoreWaitingStatus status;
 
     @Column(name = "channel", nullable = false)

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -5,6 +5,7 @@ import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.StoreWaitingStatus;
 import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingStatus;
 import im.fooding.core.repository.waiting.StoreWaitingRepository;
@@ -56,5 +57,17 @@ public class StoreWaitingService {
         if (waiting.getStatus() != WaitingStatus.WAITING_OPEN) {
             throw new ApiException(ErrorCode.WAITING_NOT_OPENED);
         }
+    }
+
+    @Transactional
+    public void seat(long id) {
+        StoreWaiting storeWaiting = getStoreWaiting(id);
+
+        if (storeWaiting.getStatus() != StoreWaitingStatus.WAITING) {
+            throw new ApiException(ErrorCode.STORE_WAITING_ILLEGAL_STATE_SEAT);
+        }
+
+        storeWaiting.seat();
+        storeWaitingRepository.save(storeWaiting);
     }
 }

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.TestConstructor;
-import org.springframework.test.context.TestConstructor.AutowireMode;
 
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
@@ -211,5 +210,41 @@ class StoreWaitingServiceTest extends TestConfig {
 
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.WAITING_NOT_OPENED);
+    }
+
+    @Test
+    @DisplayName("가게 웨이팅을 착석 처리할 수 있다.")
+    public void testSeat() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
+        StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
+
+        // when
+        storeWaitingService.seat(storeWaiting.getId());
+
+        // then
+        Assertions.assertThat(storeWaiting.getStatus())
+                .isEqualTo(StoreWaitingStatus.SEATED);
+    }
+
+    @Test
+    @DisplayName("웨이팅 상태가 아닌 경우 웨이팅 처리할 수 없다.")
+    public void testSeat_fail_whenStatusIsNotWaiting() {
+        // given
+        Store store = storeRepository.save(StoreDummy.create());
+        WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
+        StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
+
+        // when
+        storeWaitingService.seat(storeWaiting.getId());
+
+        // then
+        ApiException e = assertThrows(
+                ApiException.class,
+                () -> storeWaitingService.seat(storeWaiting.getId())
+        );
+        Assertions.assertThat(e.getErrorCode())
+                .isEqualTo(ErrorCode.STORE_WAITING_ILLEGAL_STATE_SEAT);
     }
 }


### PR DESCRIPTION
## 관련 티켓
[[POS] 웨이팅 착석 API 개발](https://www.notion.so/benkang/POS-API-1d683feabad380cd94bcea941890dcac?pvs=4)

## 주요 변경사항
### api
- 웨이팅 착석 처리 end-point 추가

### core
- 웨이팅 착석 처리 기능 추가

### 기타 사항
- 가게 웨이팅 enum 값에 대해 `@Enumerated` 설정 되어 있지 않았던 status `@Enumerated` 설정