### PR TITLE
[BE-35] [User] Store 목록 조회 API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStoreController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStoreController.java
@@ -1,0 +1,35 @@
+package im.fooding.app.controller.user.store;
+
+import im.fooding.app.dto.request.user.store.UserRetrieveStoreRequest;
+import im.fooding.app.dto.response.user.device.StoreDeviceResponse;
+import im.fooding.app.dto.response.user.store.StoreResponse;
+import im.fooding.app.service.user.store.StoreApplicationService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/stores")
+@Tag(name = "User Store Controller", description = "유저 스토어 컨트롤러")
+public class UserStoreController {
+
+    private final StoreApplicationService service;
+
+    @GetMapping
+    @Operation(summary = "가게 목록 조회 - [정렬기준 : 리뷰순 / 등록순]")
+    public ApiResult<PageResponse<StoreResponse>> list(
+            @Valid @RequestBody UserRetrieveStoreRequest request
+    ) {
+        return ApiResult.ok(service.list(request));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/store/UserRetrieveStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/store/UserRetrieveStoreRequest.java
@@ -1,0 +1,32 @@
+package im.fooding.app.dto.request.user.store;
+
+import im.fooding.core.common.BasicSearch;
+import im.fooding.core.model.store.StoreSortType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.query.SortDirection;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserRetrieveStoreRequest extends BasicSearch {
+
+    @NotNull
+    @Schema(
+            description = "정렬 타입",
+            example = "RECENT",
+            allowableValues = {"RECENT", "REVIEW"}
+    )
+    private StoreSortType sortType;
+
+    @NotNull
+    @Schema(
+            description = "정렬 순서",
+            example = "ASCENDING",
+            allowableValues = {"ASCENDING", "DESCENDING"}
+    )
+    private SortDirection sortDirection;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/StoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/StoreResponse.java
@@ -1,0 +1,58 @@
+package im.fooding.app.dto.response.user.store;
+
+import im.fooding.core.model.store.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoreResponse {
+
+    @Schema(description = "id", example = "1" )
+    private Long id;
+
+    @Schema(description = "가게명", example = "홍길동 식당" )
+    private String name;
+
+    @Schema(description = "가게가 위치한 도시", example = "합정" )
+    private String city;
+
+    @Schema(description = "해당 가게의 총 리뷰 평점", example = "4.5" )
+    private float reviewScore;
+
+    @Schema(description = "해당 가게의 총 리뷰 개수", example = "246" )
+    private int reviewCount;
+
+    @Schema(description = "해당 가게의 평균 대기 시간", example = "20" )
+    private int estimatedWaitingTimeMinutes;
+
+    @Builder
+    private StoreResponse(
+            Long id,
+            String name,
+            String city,
+            float reviewScore,
+            int reviewCount,
+            int estimatedWaitingTimeMinutes
+    ) {
+        this.id = id;
+        this.name = name;
+        this.city = city;
+        this.reviewScore = reviewScore;
+        this.reviewCount = reviewCount;
+        this.estimatedWaitingTimeMinutes = estimatedWaitingTimeMinutes;
+    }
+
+    public static StoreResponse of(Store store, float reviewScore, int estimatedWaitingTime) {
+        return StoreResponse.builder()
+                .id(store.getId())
+                .name(store.getName())
+                .city(store.getCity())
+                .reviewScore(reviewScore)
+                .reviewCount(store.getReviews().size())
+                .estimatedWaitingTimeMinutes(estimatedWaitingTime)
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/store/StoreApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/store/StoreApplicationService.java
@@ -1,0 +1,62 @@
+package im.fooding.app.service.user.store;
+
+import im.fooding.app.dto.request.user.store.UserRetrieveStoreRequest;
+import im.fooding.app.dto.response.user.store.StoreResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.WaitingSetting;
+import im.fooding.core.service.store.StoreService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreApplicationService {
+
+    private final StoreService storeService;
+
+    @Transactional(readOnly = true)
+    public PageResponse<StoreResponse> list(UserRetrieveStoreRequest request) {
+        Pageable pageable = PageRequest.of(request.getPageNum()-1, request.getPageSize());
+
+        Page<Store> list = storeService.list(
+                pageable,
+                request.getSortType(),
+                request.getSortDirection()
+        );
+
+        List<StoreResponse> storeResponses = list.stream()
+                .map(this::mapToStoreResponse)
+                .toList();
+
+        return PageResponse.of(storeResponses, PageInfo.of(list));
+    }
+
+    private StoreResponse mapToStoreResponse(Store store) {
+        float reviewScore = calculateAverageReviewScore(store);
+        int estimatedWaitingTime = calculateEstimatedWaitingTime(store);
+        return StoreResponse.of(store, reviewScore, estimatedWaitingTime);
+    }
+
+    private float calculateAverageReviewScore(Store store) {
+        return (float) store.getReviews().stream()
+                .mapToDouble(review -> review.getScore().getTotal())
+                .average()
+                .orElse(0.0);
+    }
+
+    private int calculateEstimatedWaitingTime(Store store) {
+        return store.getWaitings().stream()
+                .flatMap(w -> w.getWaitingSettings().stream())
+                .filter(WaitingSetting::isActive)
+                .mapToInt(WaitingSetting::getEstimatedWaitingTimeMinutes)
+                .min()
+                .orElse(0);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/review/Review.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/review/Review.java
@@ -73,6 +73,10 @@ public class Review extends BaseEntity {
         this.visitPurposeType = visitPurposeType;
     }
 
+    public void addReceipt(Store store) {
+        this.store = store;
+    }
+
     public void update(ReviewScore score, String content, VisitPurposeType visitPurposeType) {
         this.score = score;
         this.content = content;

--- a/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
@@ -1,11 +1,17 @@
 package im.fooding.core.model.store;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.review.Review;
+import im.fooding.core.model.waiting.Waiting;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,8 +70,14 @@ public class Store extends BaseEntity {
     @Column(nullable = false)
     private boolean isTakeOut;
 
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Waiting> waitings = new ArrayList<>();
+
     @Builder
-    public Store(
+    private Store(
             String name,
             String city,
             String address,
@@ -93,6 +105,20 @@ public class Store extends BaseEntity {
         this.isParkingAvailable = isParkingAvailable;
         this.isNewOpen = isNewOpen;
         this.isTakeOut = isTakeOut;
+    }
+
+    public void addReview(Review review) {
+        this.reviews.add(review);
+        if (review.getStore() != this) {
+            review.addReceipt(this);
+        }
+    }
+
+    public void addWaiting(Waiting waiting) {
+        this.waitings.add(waiting);
+        if (waiting.getStore() != this) {
+            waiting.addStore(this);
+        }
     }
 
     public void updateStoreName(String name) {

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StoreImage.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StoreImage.java
@@ -1,0 +1,58 @@
+package im.fooding.core.model.store;
+
+import im.fooding.core.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class StoreImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "store_id",
+            nullable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    private Store store;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Builder
+    private StoreImage(Store store, String imageUrl, int sortOrder) {
+        this.store = store;
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StoreSortType.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StoreSortType.java
@@ -1,0 +1,6 @@
+package im.fooding.core.model.store;
+
+public enum StoreSortType {
+    RECENT,
+    REVIEW;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/Waiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/Waiting.java
@@ -3,6 +3,8 @@ package im.fooding.core.model.waiting;
 import im.fooding.core.model.BaseEntity;
 import im.fooding.core.model.store.Store;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,9 +29,22 @@ public class Waiting extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private WaitingStatus status;
 
+    @OneToMany(mappedBy = "waiting", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WaitingSetting> waitingSettings = new ArrayList<>();
+
     public Waiting(Store store, WaitingStatus status) {
         this.store = store;
         this.status = status;
+    }
+
+    public void addWaitingSetting(WaitingSetting waitingSetting) {
+        this.waitingSettings.add(waitingSetting);
+        if (waitingSetting.getWaiting() != this) {
+            waitingSetting.addWaiting(this);
+        }
+    }
+    public void addStore(Store store) {
+        this.store = store;
     }
 
     public void updateStatus(WaitingStatus status) {

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingSetting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingSetting.java
@@ -69,4 +69,8 @@ public class WaitingSetting extends BaseEntity {
     public void deactivate() {
         this.isActive = false;
     }
+
+    public void addWaiting(Waiting waiting) {
+        this.waiting = waiting;
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepository.java
@@ -1,0 +1,16 @@
+package im.fooding.core.repository.store;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreSortType;
+import org.hibernate.query.SortDirection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QStoreRepository {
+
+    Page<Store> list(
+            Pageable pageable,
+            StoreSortType sortType,
+            SortDirection sortDirection
+    );
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepositoryImpl.java
@@ -1,0 +1,59 @@
+package im.fooding.core.repository.store;
+
+import static com.querydsl.core.types.Order.*;
+import static im.fooding.core.model.review.QReview.review;
+import static im.fooding.core.model.store.QStore.store;
+import static im.fooding.core.model.store.QStoreImage.storeImage;
+import static im.fooding.core.model.waiting.QWaiting.waiting;
+import static im.fooding.core.model.waiting.QWaitingSetting.waitingSetting;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreSortType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.query.SortDirection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class QStoreRepositoryImpl implements QStoreRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Page<Store> list(
+            Pageable pageable,
+            StoreSortType sortType,
+            SortDirection sortDirection
+    ) {
+        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortType, sortDirection);
+
+        List<Store> content = query
+                .select(store)
+                .from(store)
+                .leftJoin(store.reviews, review)
+                .groupBy(store.id)
+                .orderBy(orderSpecifier)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPQLQuery<Long> countQuery = query.select(store.count()).from(store);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(StoreSortType sortType, SortDirection direction) {
+        return switch (sortType) {
+            case REVIEW -> new OrderSpecifier<>
+                    (direction == SortDirection.ASCENDING ? ASC : DESC, review.count());
+            case RECENT -> new OrderSpecifier<>
+                    (direction == SortDirection.ASCENDING ? ASC : DESC, store.createdAt);
+        };
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/StoreRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/StoreRepository.java
@@ -3,5 +3,5 @@ package im.fooding.core.repository.store;
 import im.fooding.core.model.store.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreRepository extends JpaRepository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long>, QStoreRepository {
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -1,0 +1,37 @@
+package im.fooding.core.service.store;
+
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreSortType;
+import im.fooding.core.repository.store.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.query.SortDirection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    /**
+     * 가게 목록 조회
+     * TODO : 대기시간 순 정렬 추가
+     *
+     * @param pageable
+     * @param sortType
+     * @param sortDirection
+     */
+    public Page<Store> list(
+            Pageable pageable,
+            StoreSortType sortType,
+            SortDirection sortDirection
+    ) {
+        return storeRepository.list(pageable, sortType, sortDirection);
+    }
+}


### PR DESCRIPTION
## 관련 티켓

https://www.notion.so/benkang/User-Store-API-1d783feabad380e8a1bad7405f93814a?pvs=4

## 논의 사항
* 먼저 이번 API를 구현하면서 많은 고민이 있었습니다. 정렬을 하기 위해 엔드포인트를 분기할지 말지에 대한 고민부터 다대일 관계에 놓여져 있는 도메인 간의 양방향 관계를 맺을지.. 멀티 모듈로 구성되어 있어 코어 모듈에서 DTO로 반환받아도 될지에 대한 고민까지 이러한 고민을 제가 다 해결하기에는 너무 딜레이 될 거 같아 지금까지 구현된 내용을 바탕으로 먼저 PR을 올렸습니다. 

* 아마 지금까지 구현된 진행상황이 많이 잘못되었을 수 있어 많은 지적과 피드백을 남겨주시며 감사하겠습니다.

## 구현 내용

* StoreImage 도메인 모델링 추가
: Store 도메인 모델링 작업 진행 시, 추가하지 못하고 Merge 하여 지금 같이 추가하였습니다. 다음엔 분리하여 작업하도록 하겠습니다..

* `UserRetrieveStoreRequest` :  ENUM 타입으로 리뷰/등록순으로 조회가 가능하도록 하기 위한 Request DTO

* `Store - Review` : 양방향 관계 설정
* `Store - Waiting` : 양방향 관계 설정
* `Waiting - WaitingSetting` : 양방향 관계 설정
: 양방향 관계를 맺지 않고 단방향으로 최대한 해결하고자 하였으나, 양방향으로 구현하는 것이 로직에 적합하다고 판단하였습니다. 이에 관해 피드백 남겨주시면 감사하겠습니다.

