### PR TITLE
[BE-32] [User] Notificaition 저장 시, 메시지이면 메시지 슬랙 보내기

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/service/admin/notification/AdminNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/notification/AdminNotificationApplicationService.java
@@ -3,7 +3,9 @@ package im.fooding.app.service.admin.notification;
 import im.fooding.app.dto.request.admin.notification.AdminCreateNotificationRequest;
 import im.fooding.app.dto.request.admin.notification.AdminUpdateNotificationRequest;
 import im.fooding.app.dto.response.admin.notification.AdminNotificationResponse;
+import im.fooding.core.global.infra.slack.SlackClient;
 import im.fooding.core.model.notification.Notification;
+import im.fooding.core.model.notification.NotificationChannel;
 import im.fooding.core.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +21,7 @@ import java.util.List;
 public class AdminNotificationApplicationService {
 
     private final NotificationService notificationService;
+    private final SlackClient slackClient;
 
     public List<AdminNotificationResponse> list() {
       return notificationService.findAll().stream()
@@ -31,26 +34,38 @@ public class AdminNotificationApplicationService {
     return AdminNotificationResponse.of(notification);
     }
 
-    @Transactional
-    public Long create(AdminCreateNotificationRequest request) {
-      String destinationString = String.join(",", request.getDestinations());
+  @Transactional
+  public Long create(AdminCreateNotificationRequest request) {
+    String destinationString = String.join(",", request.getDestinations());
 
-      Notification notification = Notification.builder()
-              .source((request.getSource()))
-              .destination(destinationString)
-              .title(request.getTitle())
-              .content(request.getContent())
-              .channel(request.getChannel())
-              .build();
+    Notification notification = Notification.builder()
+            .source((request.getSource()))
+            .destination(destinationString)
+            .title(request.getTitle())
+            .content(request.getContent())
+            .channel(request.getChannel())
+            .build();
 
-      if (request.getScheduledAt() != null) {
-        notification.schedule(request.getScheduledAt());
-      } else {
-        notification.send();
-      }
-
-      return notificationService.create(notification).getId();
+    if (request.getScheduledAt() != null) {
+      notification.schedule(request.getScheduledAt());
+    } else {
+      notification.send();
     }
+
+    Notification savedNotification = notificationService.create(notification);
+
+    if (notification.getChannel() == NotificationChannel.MESSAGE) {
+      String slackMessage = String.format(
+              "📢 알림 메시지 \n- 제목: %s\n- 내용: %s\n- 수신자: %s",
+              notification.getTitle(),
+              notification.getContent(),
+              notification.getDestination()
+      );
+      slackClient.sendNotificationMessage(slackMessage);
+    }
+
+    return savedNotification.getId();
+  }
 
     @Transactional
     public void update(Long id, AdminUpdateNotificationRequest request) {

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationChannel.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationChannel.java
@@ -1,5 +1,5 @@
 package im.fooding.core.model.notification;
 
 public enum NotificationChannel {
-    SMS, MAIL, PUSH, KAKAO;
+    SMS, MAIL, PUSH, KAKAO, MESSAGE;
 }


### PR DESCRIPTION
[BE-32]

#### 🙆‍♀️티켓
[[User] Notificaition 저장 시, 메시지이면 메시지 슬랙 보내기](https://www.notion.so/benkang/User-Notificaiton-1d683feabad380549510d2c386b22bc9?pvs=4)

##

#### 🙆‍♀️상세 설명
[ API ]
`AdminNotificationApplicationService` -  Slack 메시지 발송 로직 추가

[ Core ]
`NotificationChannel` - MESSAGE 채널 추가

##

#### 🙆‍♀️테스트 결과
![Slack 테스트 성공](https://github.com/user-attachments/assets/1e1f5a06-daa6-4f7a-816b-b6a6cc07f3a8)
