### PR TITLE
[BE-31] [POS] 웨이팅 상태 변경 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -1,5 +1,6 @@
 package im.fooding.app.controller.waiting;
 
+import im.fooding.app.dto.request.waiting.PosWaitingStatusUpdateRequest;
 import im.fooding.app.service.waiting.PosWaitingApplicationService;
 import im.fooding.core.common.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,6 +40,18 @@ public class PosWaitingController {
             @PathVariable long requestId
     ) {
         posWaitingApplicationService.call(requestId);
+        return ApiResult.ok();
+    }
+
+    @PatchMapping("/{id}/status")
+    @Operation(summary = "웨이팅 상태 변경")
+    ApiResult<Void> updateWaitingStatus(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long id,
+
+            PosWaitingStatusUpdateRequest request
+    ) {
+        posWaitingApplicationService.updateWaitingStatus(id, request.status());
         return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/PosWaitingStatusUpdateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/PosWaitingStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package im.fooding.app.dto.request.waiting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record PosWaitingStatusUpdateRequest(
+        @NotBlank
+        @Schema(description = "웨이팅 상태(WAITING_OPEN, IMMEDIATE_ENTRY, PAUSED, WAITING_CLOSE)", example = "PAUSED")
+        String status
+) {
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
@@ -6,6 +6,8 @@ import im.fooding.app.service.user.notification.UserNotificationApplicationServi
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.waiting.*;
 import im.fooding.core.service.waiting.StoreWaitingService;
 import im.fooding.core.service.waiting.WaitingService;
@@ -58,5 +60,24 @@ public class PosWaitingApplicationService {
                 storeWaiting.getCallNumber(),
                 waitingSetting.getEntryTimeLimitMinutes()
         );
+    }
+
+    @Transactional
+    public void updateWaitingStatus(long id, String statusValue) {
+        Waiting waiting = waitingService.getById(id);
+        WaitingStatus updatedStatus = WaitingStatus.of(statusValue);
+
+        validateUpdateWaitingStatus(waiting, updatedStatus);
+
+        waitingService.updateStatus(id, updatedStatus);
+    }
+
+    private void validateUpdateWaitingStatus(Waiting waiting, WaitingStatus updatedStatus) {
+        if (!waiting.isOpen()
+                && updatedStatus == WaitingStatus.WAITING_OPEN
+                && storeWaitingService.exists(waiting.getStore(), StoreWaitingStatus.WAITING)
+        ) {
+            throw new ApiException(ErrorCode.WAITING_STATUS_STORE_WAITING_EXIST);
+        }
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     STORE_WAITING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3002", "등록된 가게 웨이팅이 없습니다."),
     STORE_WAITING_ILLEGAL_STATE_CALL(HttpStatus.BAD_REQUEST, "3003", "호출할 가능한 웨이팅 상태가 아닙니다."),
     ACTIVE_WAITING_SETTING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3004", "활성화된 웨이팅 세팅이 없습니다."),
+    WAITING_STATUS_STORE_WAITING_EXIST(HttpStatus.BAD_REQUEST, "3005", "남아있는 대기중인 웨이팅이 존재합니다."),
 
     // 디바이스
     DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "7000", "등록된 디바이스가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/Waiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/Waiting.java
@@ -40,4 +40,8 @@ public class Waiting extends BaseEntity {
     public void updateStatus(WaitingStatus status) {
         this.status = status;
     }
+
+    public boolean isOpen() {
+        return status == WaitingStatus.WAITING_OPEN;
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingStatus.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingStatus.java
@@ -1,10 +1,26 @@
 package im.fooding.core.model.waiting;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum WaitingStatus {
-    WAITING_OPEN, IMMEDIATE_ENTRY, PAUSED;
+    WAITING_OPEN("WAITING_OPEN"),
+    IMMEDIATE_ENTRY("IMMEDIATE_ENTRY"),
+    PAUSED("PAUSED"),
+    WAITING_CLOSE("WAITING_CLOSE"),
+    ;
+
+    private final String value;
+
+    public static WaitingStatus of(String value) {
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ErrorCode.METHOD_ARGUMENT_NOT_VALID);
+        }
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
@@ -1,5 +1,6 @@
 package im.fooding.core.repository.waiting;
 
+import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.StoreWaitingStatus;
 import java.time.LocalDateTime;
@@ -8,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface StoreWaitingRepository extends JpaRepository<StoreWaiting, Long>, QStoreWaitingRepository {
 
     long countByStatusAndCreatedAtBefore(StoreWaitingStatus status, LocalDateTime createdAt);
+
+    boolean existsByStoreAndStatus(Store store, StoreWaitingStatus status);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -3,6 +3,7 @@ package im.fooding.core.service.waiting;
 import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.StoreWaitingChannel;
 import im.fooding.core.model.waiting.StoreWaitingStatus;
@@ -78,5 +79,9 @@ public class StoreWaitingService {
                 storeWaiting.getStatus(),
                 storeWaiting.getCreatedAt()
         ) + 1;
+    }
+
+    public boolean exists(Store store, StoreWaitingStatus status) {
+        return storeWaitingRepository.existsByStoreAndStatus(store, status);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingService.java
@@ -3,6 +3,7 @@ package im.fooding.core.service.waiting;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.waiting.Waiting;
+import im.fooding.core.model.waiting.WaitingStatus;
 import im.fooding.core.repository.waiting.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,5 +21,11 @@ public class WaitingService {
     public Waiting getById(long id) {
         return waitingRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ErrorCode.WAITING_NOT_FOUND));
+    }
+
+    @Transactional
+    public void updateStatus(long id, WaitingStatus status) {
+        Waiting waiting = getById(id);
+        waiting.updateStatus(status);
     }
 }


### PR DESCRIPTION
## 관련 티켓
[[POS] 웨이팅 상태 변경 API 개발](https://www.notion.so/benkang/POS-API-1d683feabad38073a1d7d97f90fb8dec?pvs=4)

## 주요 변경사항

#### PosWaitingController.java
-  웨이팅 상태 변경 end-point 추가: `/pos/waitings/{id}/status`

#### PosWaitingApplicationService.java
- 웨이팅 상태 변경 비즈니스 로직 처리 메서드 생성
- 상태 변경 검증 메서드 private으로 분리
  - "접수중 -> 접수중이 아닌 상태" 변경시 웨이팅 상태의 가게 웨이팅이 있다면 예외 발생