### PR TITLE
[BE-40] [POS] 웨이팅 등록 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -1,6 +1,6 @@
 package im.fooding.app.controller.waiting;
 
-import im.fooding.app.service.waiting.PosWaitingApplicationService;
+import im.fooding.app.service.waiting.PosWaitingService;
 import im.fooding.core.common.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class PosWaitingController {
 
-    private final PosWaitingApplicationService posWaitingApplicationService;
+    private final PosWaitingService posWaitingService;
 
     @GetMapping("/{id}/requests")
     @Operation(summary = "웨이팅 목록 조회")
@@ -29,7 +29,7 @@ public class PosWaitingController {
 
             @ModelAttribute WaitingListRequest request
     ) {
-        return ApiResult.ok(posWaitingApplicationService.list(id, request));
+        return ApiResult.ok(posWaitingService.list(id, request));
     }
 
     @PostMapping("/requests/{requestId}/call")
@@ -38,7 +38,7 @@ public class PosWaitingController {
             @Parameter(description = "가게 웨이팅 id", example = "1")
             @PathVariable long requestId
     ) {
-        posWaitingApplicationService.call(requestId);
+        posWaitingService.call(requestId);
         return ApiResult.ok();
     }
 
@@ -48,7 +48,7 @@ public class PosWaitingController {
             @Parameter(description = "가게 웨이팅 id", example = "1")
             @PathVariable long requestId
     ) {
-        posWaitingApplicationService.seat(requestId);
+        posWaitingService.seat(requestId);
         return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -1,5 +1,6 @@
 package im.fooding.app.controller.waiting;
 
+import im.fooding.app.dto.request.waiting.PosWaitingRegisterRequest;
 import im.fooding.app.service.waiting.PosWaitingService;
 import im.fooding.core.common.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
 import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.core.common.PageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -49,6 +51,18 @@ public class PosWaitingController {
             @PathVariable long requestId
     ) {
         posWaitingService.seat(requestId);
+        return ApiResult.ok();
+    }
+
+    @PostMapping("/{id}/requests")
+    @Operation(summary = "웨이팅 등록")
+    ApiResult<Void> register(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long id,
+
+            @RequestBody @Valid PosWaitingRegisterRequest request
+    ) {
+        posWaitingService.register(id, request);
         return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/PosWaitingRegisterRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/PosWaitingRegisterRequest.java
@@ -1,0 +1,41 @@
+package im.fooding.app.dto.request.waiting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record PosWaitingRegisterRequest(
+        @Schema(description = "웨이팅 유저 이름", example = "홍길동")
+        String name,
+
+        @Schema(description = "핸드폰 번호", example = "01012345678")
+        String phoneNumber,
+
+        @NotNull
+        @Schema(description = "서비스 이용약관 동의", example = "true")
+        Boolean termsAgreed,
+
+        @NotNull
+        @Schema(description = "개인정보 수집 및 이용 동의", example = "true")
+        Boolean privacyPolicyAgreed,
+
+        @NotNull
+        @Schema(description = "개인정보 제3자 제공 동의", example = "true")
+        Boolean thirdPartyAgreed,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "필요한 유아용 의자 개수", example = "1")
+        Integer infantChairCount,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "유아 입장 인원수", example = "1")
+        Integer infantCount,
+
+        @NotNull
+        @PositiveOrZero
+        @Schema(description = "성인 입장 인원수", example = "1")
+        Integer adultCount
+) {
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
-public class PosWaitingApplicationService {
+public class PosWaitingService {
 
     private final UserNotificationApplicationService userNotificationApplicationService;
     private final WaitingService waitingService;

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
@@ -1,15 +1,21 @@
 package im.fooding.app.service.waiting;
 
+import im.fooding.app.dto.request.waiting.PosWaitingRegisterRequest;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
 import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.app.service.user.notification.UserNotificationApplicationService;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
+import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
+import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.*;
 import im.fooding.core.service.waiting.StoreWaitingService;
+import im.fooding.core.service.waiting.WaitingLogService;
 import im.fooding.core.service.waiting.WaitingService;
 import im.fooding.core.service.waiting.WaitingSettingService;
+import im.fooding.core.service.waiting.WaitingUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -28,6 +34,8 @@ public class PosWaitingService {
     private final WaitingService waitingService;
     private final StoreWaitingService storeWaitingService;
     private final WaitingSettingService waitingSettingService;
+    private final WaitingLogService waitingLogService;
+    private final WaitingUserService waitingUserService;
 
     public PageResponse<WaitingResponse> list(long id, WaitingListRequest request) {
 
@@ -62,6 +70,68 @@ public class PosWaitingService {
                 storeWaiting.getStoreName(),
                 storeWaiting.getCallNumber(),
                 waitingSetting.getEntryTimeLimitMinutes()
+        );
+    }
+
+    @Transactional
+    public void register(long id, PosWaitingRegisterRequest request) {
+        Waiting waiting = waitingService.getById(id);
+        storeWaitingService.validate(waiting);
+
+        String name = request.name();
+        String phoneNumber = request.phoneNumber();
+
+        WaitingUser waitingUser = null;
+        if ((name != null && !name.isBlank())
+                || (phoneNumber != null && !phoneNumber.isBlank())
+        ) {
+            waitingUser = getOrRegisterUser(request, phoneNumber, waiting);
+        }
+
+        StoreWaiting storeWaiting = registerStoreWaiting(request, waiting, waitingUser);
+
+        waitingLogService.logRegister(storeWaiting);
+
+        sendNotification(waiting, storeWaiting);
+    }
+
+    private WaitingUser getOrRegisterUser(PosWaitingRegisterRequest request, String phoneNumber, Waiting waiting) {
+        WaitingUserRegisterRequest waitingUserRegisterRequest = WaitingUserRegisterRequest.builder()
+                .store(waiting.getStore())
+                .name(request.name())
+                .phoneNumber(phoneNumber)
+                .termsAgreed(request.termsAgreed())
+                .privacyPolicyAgreed(request.privacyPolicyAgreed())
+                .thirdPartyAgreed(request.thirdPartyAgreed())
+                .marketingConsent(false)
+                .build();
+
+        return waitingUserService.getOrElseRegister(waitingUserRegisterRequest);
+    }
+
+    private StoreWaiting registerStoreWaiting(PosWaitingRegisterRequest request, Waiting waiting, WaitingUser waitingUser) {
+        StoreWaitingRegisterRequest storeWaitingRegisterRequest = StoreWaitingRegisterRequest.builder()
+                .user(waitingUser)
+                .store(waiting.getStore())
+                .channel(StoreWaitingChannel.IN_PERSON.getValue())
+                .infantChairCount(request.infantChairCount())
+                .infantCount(request.infantCount())
+                .adultCount(request.adultCount())
+                .build();
+
+        return storeWaitingService.register(storeWaitingRegisterRequest);
+    }
+
+    private void sendNotification(Waiting waiting, StoreWaiting storeWaiting) {
+        int order = storeWaitingService.getOrder(storeWaiting.getId());
+        int personnel = storeWaiting.getAdultCount() + storeWaiting.getInfantCount();
+
+        Store store = waiting.getStore();
+        userNotificationApplicationService.sendWaitingRegisterMessage(
+                store.getName(),
+                personnel,
+                order,
+                storeWaiting.getCallNumber()
         );
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -38,7 +38,7 @@ public class StoreWaiting extends BaseEntity {
     private Store store;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "waiting_user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "waiting_user_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private WaitingUser user;
 
     @Column(name = "call_number", nullable = false)

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingUser.java
@@ -34,7 +34,6 @@ public class WaitingUser extends BaseEntity {
 
     private String name;
 
-    @Column(nullable = false)
     private String phoneNumber;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 관련 티켓
[[POS] 웨이팅 등록 API](https://www.notion.so/benkang/POS-API-1d783feabad380b2b301e63d7bcee541?pvs=4)

## 주요 변경사항
- api service 네이밍 변경 
  `posWaitingApplicationService` -> `PosWaitingService`
- 웨이팅 등록 API 추가
  - APP 웨이팅 등록 API 로직과 이름, 핸드폰 번호 nullable 제외한 비즈니스 로직 동일
- `StoreWaiting.user` `nullalbe`로 변경
- `WaitingUser.phonenumber` `nullable`로 변경