### PR TITLE
[BE-41] [POS] 웨이팅 상세 조회 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -1,6 +1,6 @@
 package im.fooding.app.controller.waiting;
 
-import im.fooding.app.service.waiting.PosWaitingApplicationService;
+import im.fooding.app.service.waiting.PosWaitingService;
 import im.fooding.core.common.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class PosWaitingController {
 
-    private final PosWaitingApplicationService posWaitingApplicationService;
+    private final PosWaitingService posWaitingService;
 
     @GetMapping("/{id}/requests")
     @Operation(summary = "웨이팅 목록 조회")
@@ -29,7 +29,7 @@ public class PosWaitingController {
 
             @ModelAttribute WaitingListRequest request
     ) {
-        return ApiResult.ok(posWaitingApplicationService.list(id, request));
+        return ApiResult.ok(posWaitingService.list(id, request));
     }
 
     @PostMapping("/requests/{requestId}/call")
@@ -38,7 +38,7 @@ public class PosWaitingController {
             @Parameter(description = "가게 웨이팅 id", example = "1")
             @PathVariable long requestId
     ) {
-        posWaitingApplicationService.call(requestId);
+        posWaitingService.call(requestId);
         return ApiResult.ok();
     }
 
@@ -48,7 +48,7 @@ public class PosWaitingController {
             @Parameter(description = "가게 웨이팅 id", example = "1")
             @PathVariable long requestId
     ) {
-        posWaitingApplicationService.seat(requestId);
+        posWaitingService.seat(requestId);
         return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -1,7 +1,10 @@
 package im.fooding.app.controller.waiting;
 
+import im.fooding.app.dto.response.waiting.StoreWaitingResponse;
+import im.fooding.app.dto.response.waiting.WaitingLogResponse;
 import im.fooding.app.service.waiting.PosWaitingService;
 import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.BasicSearch;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,6 +33,27 @@ public class PosWaitingController {
             @ModelAttribute WaitingListRequest request
     ) {
         return ApiResult.ok(posWaitingService.list(id, request));
+    }
+
+    @GetMapping("/requests/{requestId}")
+    @Operation(summary = "웨이팅 상세 조회")
+    public ApiResult<StoreWaitingResponse> details(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long requestId
+    ) {
+        return ApiResult.ok(posWaitingService.details(requestId));
+    }
+
+    @GetMapping("/requests/{requestId}/logs")
+    @Operation(summary = "웨이팅 로그 리스트 조회")
+    public ApiResult<PageResponse<WaitingLogResponse>> listLogs(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long requestId,
+
+            @Parameter(description = "검색 및 페이징 조건")
+            @ModelAttribute BasicSearch search
+    ) {
+        return ApiResult.ok(posWaitingService.listLogs(requestId, search));
     }
 
     @PostMapping("/requests/{requestId}/call")

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
@@ -1,13 +1,17 @@
 package im.fooding.app.service.waiting;
 
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
+import im.fooding.app.dto.response.waiting.StoreWaitingResponse;
+import im.fooding.app.dto.response.waiting.WaitingLogResponse;
 import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.app.service.user.notification.UserNotificationApplicationService;
+import im.fooding.core.common.BasicSearch;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
 import im.fooding.core.model.waiting.*;
 import im.fooding.core.service.waiting.StoreWaitingService;
+import im.fooding.core.service.waiting.WaitingLogService;
 import im.fooding.core.service.waiting.WaitingService;
 import im.fooding.core.service.waiting.WaitingSettingService;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +32,11 @@ public class PosWaitingService {
     private final WaitingService waitingService;
     private final StoreWaitingService storeWaitingService;
     private final WaitingSettingService waitingSettingService;
+    private final WaitingLogService waitingLogService;
+
+    public StoreWaitingResponse details(long id) {
+        return StoreWaitingResponse.from(storeWaitingService.getStoreWaiting(id));
+    }
 
     public PageResponse<WaitingResponse> list(long id, WaitingListRequest request) {
 
@@ -63,5 +72,16 @@ public class PosWaitingService {
                 storeWaiting.getCallNumber(),
                 waitingSetting.getEntryTimeLimitMinutes()
         );
+    }
+
+    public PageResponse<WaitingLogResponse> listLogs(long requestId, BasicSearch search) {
+        Page<WaitingLog> logs = waitingLogService.list(requestId, search.getPageable());
+
+        List<WaitingLogResponse> list = logs.getContent()
+                .stream()
+                .map(WaitingLogResponse::from)
+                .toList();
+
+        return PageResponse.of(list, PageInfo.of(logs));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
@@ -35,7 +35,7 @@ public class PosWaitingService {
     private final WaitingLogService waitingLogService;
 
     public StoreWaitingResponse details(long id) {
-        return StoreWaitingResponse.from(storeWaitingService.getStoreWaiting(id));
+        return StoreWaitingResponse.from(storeWaitingService.get(id));
     }
 
     public PageResponse<WaitingResponse> list(long id, WaitingListRequest request) {

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
-public class PosWaitingApplicationService {
+public class PosWaitingService {
 
     private final UserNotificationApplicationService userNotificationApplicationService;
     private final WaitingService waitingService;


### PR DESCRIPTION
## 이슈 티켓
[[POS] 웨이팅 상세 조회 API](https://www.notion.so/benkang/POS-API-1d783feabad380c2ab66edcc093e6de6?pvs=4)

## 주요 변경사항
### PosWaitingApplicationService 네이밍 리팩토링
- 회의에서 정한 네이밍 규칙에 따라 Service 클래스 이름 변경
  `posWaitingApplicationService` -> `PosWaitingService`

### PosWaitingController
- 웨이팅 상세 조회 API 추가
- 웨이팅  로그 리스트 조회 API 추가 (같은 UI에 존재하고, 이슈 티켓이 따로 없어서 함께 개발했습니다.)
