### PR TITLE
[BE-47] [USER] 메뉴 조회 API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/menu/UserMenuController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/menu/UserMenuController.java
@@ -1,0 +1,35 @@
+package im.fooding.app.controller.user.menu;
+
+import im.fooding.app.dto.response.user.menu.UserMenuResponse;
+import im.fooding.app.service.user.menu.UserMenuService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.BasicSearch;
+import im.fooding.core.global.UserInfo;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/store")
+@Tag(name = "UserMenuController", description = "유저 메뉴 컨트롤러")
+public class UserMenuController {
+
+    private final UserMenuService userMenuService;
+
+    @GetMapping("/{storeId}/menus")
+    public ApiResult<List<UserMenuResponse>> list(
+            @PathVariable Long storeId
+    ) {
+        List<UserMenuResponse> menus = userMenuService.list(storeId);
+        return ApiResult.ok(menus);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/menu/UserMenuController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/menu/UserMenuController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user/store")
+@RequestMapping("/user/stores")
 @Tag(name = "UserMenuController", description = "유저 메뉴 컨트롤러")
 public class UserMenuController {
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/MenuResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/MenuResponse.java
@@ -1,0 +1,70 @@
+package im.fooding.app.dto.response.user.menu;
+
+import im.fooding.core.model.menu.Menu;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MenuResponse {
+
+    @Schema(description = "메뉴 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "메뉴 이름", example = "김치찌개")
+    private String name;
+
+    @Schema(description = "메뉴 설명", example = "매운 김치찌개")
+    private String description;
+
+    @Schema(description = "메뉴 이미지 URL", example = "https://example.com/image.jpg")
+    private String imageUrl;
+
+    @Schema(description = "메뉴 가격", example = "10000")
+    private int price;
+
+    @Schema(description = "메뉴 정렬 순서", example = "1")
+    private int sortOrder;
+
+    @Schema(description = "대표 메뉴 여부", example = "true")
+    private boolean isSignature;
+
+    @Schema(description = "메뉴 추천 여부", example = "true")
+    private boolean isRecommend;
+
+    @Builder
+    private MenuResponse(
+            Long id,
+            String name,
+            String description,
+            String imageUrl,
+            int price,
+            int sortOrder,
+            boolean isSignature,
+            boolean isRecommend
+    ) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.price = price;
+        this.sortOrder = sortOrder;
+        this.isSignature = isSignature;
+        this.isRecommend = isRecommend;
+    }
+
+    public static MenuResponse of(Menu menu) {
+        return MenuResponse.builder()
+                .id(menu.getId())
+                .name(menu.getName())
+                .description(menu.getDescription())
+                .imageUrl(menu.getImageUrl())
+                .price(menu.getPrice().intValue())
+                .sortOrder(menu.getSortOrder())
+                .isSignature(menu.isSignature())
+                .isRecommend(menu.isRecommend())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/UserMenuResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/UserMenuResponse.java
@@ -1,0 +1,42 @@
+package im.fooding.app.dto.response.user.menu;
+
+import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserMenuResponse {
+
+    @Schema(description = "카테고리 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "카테고리 이름", example = "식사류")
+    private String categoryName;
+
+    @Schema(description = "메뉴 리스트")
+    private List<MenuResponse> menu;
+
+    @Builder
+    private UserMenuResponse(
+            Long id,
+            String categoryName,
+            List<MenuResponse> menu
+    ) {
+        this.id = id;
+        this.categoryName = categoryName;
+        this.menu = menu;
+    }
+
+    public static UserMenuResponse of(MenuCategory category, List<Menu> menus) {
+        return UserMenuResponse.builder()
+                .id(category.getId())
+                .categoryName(category.getName())
+                .menu(menus.stream().map(MenuResponse::of).toList())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
@@ -1,11 +1,8 @@
 package im.fooding.app.service.user.menu;
 
 import im.fooding.app.dto.response.user.menu.UserMenuResponse;
-import im.fooding.core.model.menu.Menu;
-import im.fooding.core.model.menu.MenuCategory;
+import im.fooding.core.service.menu.MenuCategoryService;
 import im.fooding.core.service.menu.MenuService;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +13,10 @@ import org.springframework.stereotype.Service;
 public class UserMenuService {
 
     private final MenuService menuService;
+    private final MenuCategoryService menuCategoryService;
 
     public List<UserMenuResponse> list(Long storeId) {
-        return menuService.list(storeId).stream()
+        return menuCategoryService.list(storeId).stream()
                 .map(category -> UserMenuResponse.of(category, menuService.list(category)
                 ))
                 .collect(Collectors.toList());

--- a/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
@@ -1,9 +1,12 @@
 package im.fooding.app.service.user.menu;
 
 import im.fooding.app.dto.response.user.menu.UserMenuResponse;
+import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuCategory;
 import im.fooding.core.service.menu.MenuCategoryService;
 import im.fooding.core.service.menu.MenuService;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,9 +19,22 @@ public class UserMenuService {
     private final MenuCategoryService menuCategoryService;
 
     public List<UserMenuResponse> list(Long storeId) {
-        return menuCategoryService.list(storeId).stream()
-                .map(category -> UserMenuResponse.of(category, menuService.list(category)
+        List<MenuCategory> menuCategoryList = menuCategoryService.list(storeId);
+
+        Map<Long, List<Menu>> menuList = menuService
+                .list(menuCategoryList
+                        .stream()
+                        .map(MenuCategory::getId)
+                        .toList()
+                )
+                .stream()
+                .collect(Collectors.groupingBy(menu -> menu.getCategory().getId()));
+
+        return menuCategoryList.stream()
+                .map(category -> UserMenuResponse.of(
+                        category,
+                        menuList.getOrDefault(category.getId(), List.of())
                 ))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
@@ -1,0 +1,26 @@
+package im.fooding.app.service.user.menu;
+
+import im.fooding.app.dto.response.user.menu.UserMenuResponse;
+import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuCategory;
+import im.fooding.core.service.menu.MenuService;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserMenuService {
+
+    private final MenuService menuService;
+
+    public List<UserMenuResponse> list(Long storeId) {
+        return menuService.list(storeId).stream()
+                .map(category -> UserMenuResponse.of(category, menuService.list(category)
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuCategoryRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuCategoryRepository.java
@@ -1,0 +1,11 @@
+package im.fooding.core.repository.menu;
+
+import im.fooding.core.model.menu.MenuCategory;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuCategoryRepository extends JpaRepository<MenuCategory, Long> {
+
+    List<MenuCategory> findAllByStoreId(long storeId);
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuCategoryRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuCategoryRepository.java
@@ -2,10 +2,9 @@ package im.fooding.core.repository.menu;
 
 import im.fooding.core.model.menu.MenuCategory;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuCategoryRepository extends JpaRepository<MenuCategory, Long> {
 
-    List<MenuCategory> findAllByStoreId(long storeId);
+    List<MenuCategory> findAllByStoreIdAndDeletedFalse(long storeId);
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuRepository.java
@@ -1,0 +1,8 @@
+package im.fooding.core.repository.menu;
+
+import im.fooding.core.model.menu.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long>, QMenuRepository {
+
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepository.java
@@ -1,11 +1,10 @@
 package im.fooding.core.repository.menu;
 
 import im.fooding.core.model.menu.Menu;
-import im.fooding.core.model.menu.MenuCategory;
 import java.util.List;
 
 public interface QMenuRepository {
 
-    List<Menu> list(MenuCategory menuCategory);
+    List<Menu> list(List<Long> categoryIds);
 
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepository.java
@@ -1,0 +1,11 @@
+package im.fooding.core.repository.menu;
+
+import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuCategory;
+import java.util.List;
+
+public interface QMenuRepository {
+
+    List<Menu> list(MenuCategory menuCategory);
+
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepositoryImpl.java
@@ -17,6 +17,7 @@ public class QMenuRepositoryImpl implements QMenuRepository {
         return queryFactory
                 .selectFrom(menu)
                 .where(menu.category.id.in(categoryIds))
+                .where(menu.deleted.isFalse())
                 .fetch();
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepositoryImpl.java
@@ -4,7 +4,6 @@ import static im.fooding.core.model.menu.QMenu.menu;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import im.fooding.core.model.menu.Menu;
-import im.fooding.core.model.menu.MenuCategory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -14,13 +13,10 @@ public class QMenuRepositoryImpl implements QMenuRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Menu> list(MenuCategory menuCategory) {
-
+    public List<Menu> list(List<Long> categoryIds) {
         return queryFactory
                 .selectFrom(menu)
-                .where(menu.category.eq(menuCategory))
-                .orderBy(menu.sortOrder.asc())
+                .where(menu.category.id.in(categoryIds))
                 .fetch();
-
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuRepositoryImpl.java
@@ -1,0 +1,26 @@
+package im.fooding.core.repository.menu;
+
+import static im.fooding.core.model.menu.QMenu.menu;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuCategory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class QMenuRepositoryImpl implements QMenuRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Menu> list(MenuCategory menuCategory) {
+
+        return queryFactory
+                .selectFrom(menu)
+                .where(menu.category.eq(menuCategory))
+                .orderBy(menu.sortOrder.asc())
+                .fetch();
+
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
@@ -1,8 +1,7 @@
 package im.fooding.core.service.menu;
 
-import im.fooding.core.model.menu.Menu;
 import im.fooding.core.model.menu.MenuCategory;
-import im.fooding.core.repository.menu.MenuRepository;
+import im.fooding.core.repository.menu.MenuCategoryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,18 +11,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-@Slf4j
-public class MenuService {
+public class MenuCategoryService {
 
-    private final MenuRepository menuRepository;
+    private final MenuCategoryRepository menuCategoryRepository;
+
 
     /**
-     * 메뉴 목록 조회
+     * 메뉴 카테고리 목록 조회
      *
-     * @param menuCategory
-     * @return List<Menu>
+     * @param storeId
+     * @return List<MenuCategory>
      */
-    public List<Menu> list(MenuCategory menuCategory) {
-        return menuRepository.list(menuCategory);
+    public List<MenuCategory> list(long storeId) {
+        return menuCategoryRepository.findAllByStoreId(storeId);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
@@ -4,7 +4,6 @@ import im.fooding.core.model.menu.MenuCategory;
 import im.fooding.core.repository.menu.MenuCategoryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +22,6 @@ public class MenuCategoryService {
      * @return List<MenuCategory>
      */
     public List<MenuCategory> list(long storeId) {
-        return menuCategoryRepository.findAllByStoreId(storeId);
+        return menuCategoryRepository.findAllByStoreIdAndDeletedFalse(storeId);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuService.java
@@ -1,7 +1,6 @@
 package im.fooding.core.service.menu;
 
 import im.fooding.core.model.menu.Menu;
-import im.fooding.core.model.menu.MenuCategory;
 import im.fooding.core.repository.menu.MenuRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +19,10 @@ public class MenuService {
     /**
      * 메뉴 목록 조회
      *
-     * @param menuCategory
+     * @param categoryIds
      * @return List<Menu>
      */
-    public List<Menu> list(MenuCategory menuCategory) {
-        return menuRepository.list(menuCategory);
+    public List<Menu> list(List<Long> categoryIds) {
+        return menuRepository.list(categoryIds);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuService.java
@@ -1,0 +1,41 @@
+package im.fooding.core.service.menu;
+
+import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuCategory;
+import im.fooding.core.repository.menu.MenuCategoryRepository;
+import im.fooding.core.repository.menu.MenuRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class MenuService {
+
+    private final MenuCategoryRepository menuCategoryRepository;
+    private final MenuRepository menuRepository;
+
+    /**
+     * 메뉴 목록 조회
+     *
+     * @param menuCategory
+     * @return List<Menu>
+     */
+    public List<Menu> list(MenuCategory menuCategory) {
+        return menuRepository.list(menuCategory);
+    }
+
+    /**
+     * 메뉴 카테고리 목록 조회
+     *
+     * @param storeId
+     * @return List<MenuCategory>
+     */
+    public List<MenuCategory> list(long storeId) {
+        return menuCategoryRepository.findAllByStoreId(storeId);
+    }
+}


### PR DESCRIPTION
## 관련 티켓

https://www.notion.so/benkang/User-API-1d783feabad380b9a14af417fef1df45?pvs=4

## 관련 기능

* `UserMenuResponse` - 카테고리와 해당하는 메뉴 응답 DTO
    * `MenuResponse` - 메뉴 정보 DTO

* 카테고리 내 존재하는 메뉴의 sortOrder 순으로 정렬 
* 가게당 등록되는 메뉴의 개수가 대부분 20개 이하로 페이징 처리는 하지 않았습니다.

## 리뷰 요구사항

* 현재 멀티 모듈 구조로 core모듈에서 api모듈을 의존하지 않도록 도메인으로 반환하도록 구현함에 따라 설계된 구조에 관해서 피드백 부탁드리겠습니다.

## 구현 로직

1. 가게에 등록된 카테고리들을 List로 반환
2. List에 존재하는 카테고리 ID들로 모든 메뉴들을 조회
3. 그룹핑을 통해 DTO 조립하여 반환

카테고리의 개수만큼 메뉴를 조회하도록 쿼리가 발생했지만, 위와 같이 구현하여 카테고리 리스트 쿼리 1번, 메뉴 리스트 쿼리 1번으로 총 2번의 쿼리로 해결하였습니다.
