### PR TITLE
[BE-34] [BE-48] [Admin] Notification API 리팩토링 / [User] 소식 도메인 모델링

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/notification/AdminNotificationController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/notification/AdminNotificationController.java
@@ -3,7 +3,7 @@ package im.fooding.app.controller.admin.notification;
 import im.fooding.app.dto.request.admin.notification.AdminCreateNotificationRequest;
 import im.fooding.app.dto.request.admin.notification.AdminUpdateNotificationRequest;
 import im.fooding.app.dto.response.admin.notification.AdminNotificationResponse;
-import im.fooding.app.service.admin.notification.AdminNotificationApplicationService;
+import im.fooding.app.service.admin.notification.AdminNotificationService;
 import im.fooding.core.common.ApiResult;
 import im.fooding.core.global.UserInfo;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,40 +23,40 @@ import java.util.List;
 @Slf4j
 public class AdminNotificationController {
 
-    private final AdminNotificationApplicationService adminNotificationApplicationService;
+    private final AdminNotificationService adminNotificationService;
 
     @GetMapping
     @Operation(summary = "알림 전체 조회")
     public ApiResult<List<AdminNotificationResponse>> findAll(){
-      List<AdminNotificationResponse> notifications = adminNotificationApplicationService.list();
+      List<AdminNotificationResponse> notifications = adminNotificationService.list();
       return ApiResult.ok(notifications);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "알림 상세 조회")
     public ApiResult<AdminNotificationResponse> findById(@PathVariable Long id) {
-      AdminNotificationResponse response = adminNotificationApplicationService.retrieve(id);
+      AdminNotificationResponse response = adminNotificationService.retrieve(id);
       return ApiResult.ok(response);
     }
 
     @PostMapping
     @Operation(summary = "알림 생성")
     public ApiResult<Long> create(@RequestBody @Valid AdminCreateNotificationRequest request) {
-      Long id = adminNotificationApplicationService.create(request);
+      Long id = adminNotificationService.create(request);
       return ApiResult.ok(id);
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "알림 수정")
     public ApiResult<Void> update(@PathVariable Long id, @RequestBody @Valid AdminUpdateNotificationRequest request) {
-    adminNotificationApplicationService.update(id,request);
+      adminNotificationService.update(id,request);
       return ApiResult.ok();
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "알림 삭제")
     public ApiResult<Void> delete(@PathVariable long id, @AuthenticationPrincipal UserInfo userInfo) {
-      adminNotificationApplicationService.delete(id, userInfo.getId());
+      adminNotificationService.delete(id, userInfo.getId());
       return ApiResult.ok();
       }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/notification/AdminNotificationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/notification/AdminNotificationService.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
-public class AdminNotificationApplicationService {
+public class AdminNotificationService {
 
     private final NotificationService notificationService;
     private final SlackClient slackClient;

--- a/fooding-core/src/main/java/im/fooding/core/common/StringListConverter.java
+++ b/fooding-core/src/main/java/im/fooding/core/common/StringListConverter.java
@@ -1,0 +1,27 @@
+package im.fooding.core.common;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final String SPLIT_CHAR = ",";
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+      return attribute != null ? String.join(SPLIT_CHAR, attribute) : "";
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+      return dbData != null && !dbData.isEmpty()
+              ? Arrays.stream(dbData.split(SPLIT_CHAR)).map(String::trim).collect(Collectors.toList())
+              : Collections.emptyList();
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StorePost.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StorePost.java
@@ -1,0 +1,58 @@
+package im.fooding.core.model.store;
+
+import im.fooding.core.common.StringListConverter;
+import im.fooding.core.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class StorePost extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Convert(converter = StringListConverter.class)
+    @Column(name = "tags")
+    private List<String> tags;
+
+    @ColumnDefault("false")
+    @Column(nullable = false)
+    private boolean isFixed;
+
+    @Builder
+    public StorePost(Store store, String title, String content, List<String> tags, boolean isFixed) {
+      this.store = store;
+      this.title = title;
+      this.content = content;
+      this.tags = tags;
+      this.isFixed = isFixed;
+    }
+
+    public void update(String title, String content, List<String> tags, boolean isFixed) {
+      this.title = title;
+      this.content = content;
+      this.tags = tags;
+      this.isFixed = isFixed;
+    }
+}


### PR DESCRIPTION
[BE-34] [BE-48]

#### 🧾 티켓
[[Admin] Notification API 리팩토링](https://www.notion.so/benkang/Admin-Notification-API-1d783feabad3800b941ec87d1aaacd19?pvs=4)
[[User] 소식 도메인 모델링](https://www.notion.so/benkang/User-1d783feabad380538faed90dbcbc9d41?pvs=4)

##

#### 🔧 작업 내용
Notification API 리팩토링은 네이밍만 변경되는 작업이라 별도 브랜치 없이 함께 반영했습니다.

[ API ]
`AdminNotificationService` , `AdminNotificationController` -  네이밍 수정 (회의 결과 반영)

[ Core ]
`StorePost` - 소식 도메인 엔티티
`StringListConverter` - 태그 저장을 위한 클래스