### PR TITLE
[BE-29-refactor] 가게 웨이팅 상태 되돌리기 가능한 status Set 기반으로 조건 탐색하도록 로직 변경

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -40,7 +40,7 @@ public enum ErrorCode {
     STORE_WAITING_ILLEGAL_STATE_CALL(HttpStatus.BAD_REQUEST, "3003", "호출할 가능한 웨이팅 상태가 아닙니다."),
     ACTIVE_WAITING_SETTING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3004", "활성화된 웨이팅 세팅이 없습니다."),
     STORE_WAITING_ILLEGAL_STATE_CANCEL(HttpStatus.BAD_REQUEST, "3005", "취소 가능한 웨이팅 상태가 아닙니다."),
-    STORE_WAITING_ALREADY_WAITING(HttpStatus.BAD_REQUEST, "3006", "이미 가게 웨이팅 상태입니다."),
+    STORE_WAITING_ILLEGAL_STATE_REVERT(HttpStatus.BAD_REQUEST, "3006", "이미 가게 웨이팅 상태입니다."),
     STORE_WAITING_ILLEGAL_STATE_SEAT(HttpStatus.BAD_REQUEST, "3007", "착성 가능한 웨이팅 상태가 아닙니다."),
 
     // 디바이스

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -16,6 +16,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +28,11 @@ import org.hibernate.annotations.DynamicUpdate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicUpdate
 public class StoreWaiting extends BaseEntity {
+
+    private static final Set<StoreWaitingStatus> REVERSIBLE_STATUSES = Set.of(
+            StoreWaitingStatus.CANCELLED,
+            StoreWaitingStatus.SEATED
+    );
 
     @Id
     @Column(name = "id")
@@ -110,8 +116,8 @@ public class StoreWaiting extends BaseEntity {
     }
 
     public void revert() {
-        if (status == StoreWaitingStatus.WAITING) {
-            throw new ApiException(ErrorCode.STORE_WAITING_ALREADY_WAITING);
+        if (!REVERSIBLE_STATUSES.contains(status)) {
+            throw new ApiException(ErrorCode.STORE_WAITING_ILLEGAL_STATE_REVERT);
         }
 
         status = StoreWaitingStatus.WAITING;

--- a/fooding-core/src/test/java/im/fooding/core/model/waiting/StoreWaitingTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/model/waiting/StoreWaitingTest.java
@@ -26,7 +26,7 @@ class StoreWaitingTest {
     }
 
     @Test
-    @DisplayName("이미 웨이팅 상태인 경우 되돌릴 수 없다.")
+    @DisplayName("되돌릴 수 있는 상태가 아닌 경우 되돌릴 수 없다.")
     void testRevert_fail_whenAlreadyWaiting() {
         // given
         StoreWaiting storeWaiting = StoreWaiting.builder().build();
@@ -34,7 +34,7 @@ class StoreWaitingTest {
         // when & then
         ApiException e = assertThrows(ApiException.class, storeWaiting::revert);
         Assertions.assertThat(e.getErrorCode())
-                .isEqualTo(ErrorCode.STORE_WAITING_ALREADY_WAITING);
+                .isEqualTo(ErrorCode.STORE_WAITING_ILLEGAL_STATE_REVERT);
     }
 
     @DisplayName("착석할 수 있다.")


### PR DESCRIPTION
## 관련 이슈
- #30

## 주요 변경사항
리뷰를 반영하여 웨이팅 대기열 되돌리기 메서드의 로직을 변경했습니다.
- 기존
  - status가 웨이팅 중인지 확인
- 변경 후
  - status가 revert 가능한 상태(취소, 완료 상태)인지 확인
- 추가 변경사항
  - status가 웨이팅인 경우 발생하는 예외가 아닌 현재 예외 발생 기준으로 예외 코드명 변경