### PR TITLE
[BE-45] [POS] 웨이팅 대기 시간 조정 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -1,5 +1,6 @@
 package im.fooding.app.controller.waiting;
 
+import im.fooding.app.dto.request.waiting.PosUpdateWaitingTimeRequest;
 import im.fooding.app.dto.request.waiting.PosWaitingCancelRequest;
 import im.fooding.app.service.waiting.PosWaitingApplicationService;
 import im.fooding.core.common.ApiResult;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
 import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.core.common.PageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
@@ -73,6 +75,18 @@ public class PosWaitingController {
             @PathVariable long requestId
     ) {
         posWaitingApplicationService.seat(requestId);
+        return ApiResult.ok();
+    }
+
+    @PatchMapping("/{id}/waiting-time")
+    @Operation(summary = "웨이팅 대기 시간 조정")
+    ApiResult<Void> updateWaitingTime(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long id,
+
+            @RequestBody @Valid PosUpdateWaitingTimeRequest request
+    ) {
+        posWaitingApplicationService.updateWaitingTime(id, request.estimatedWaitingTimeMinutes());
         return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/PosUpdateWaitingTimeRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/waiting/PosUpdateWaitingTimeRequest.java
@@ -1,0 +1,11 @@
+package im.fooding.app.dto.request.waiting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record PosUpdateWaitingTimeRequest(
+        @NotNull
+        @Schema(description = "팀 당 예상 시간(분)", example = "1")
+        Integer estimatedWaitingTimeMinutes
+) {
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingApplicationService.java
@@ -74,4 +74,12 @@ public class PosWaitingApplicationService {
     public void revert(long requestId) {
         storeWaitingService.revert(requestId);
     }
+
+    @Transactional
+    public void updateWaitingTime(long id, int estimatedWaitingTimeMinutes) {
+        Waiting waiting = waitingService.getById(id);
+        WaitingSetting activeSetting = waitingSettingService.getActiveSetting(waiting.getStore());
+
+        activeSetting.updateWaitingTimeMinutes(estimatedWaitingTimeMinutes);
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingSetting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/WaitingSetting.java
@@ -74,4 +74,8 @@ public class WaitingSetting extends BaseEntity {
     public void deactivate() {
         this.isActive = false;
     }
+
+    public void updateWaitingTimeMinutes(int estimatedWaitingTimeMinutes) {
+        this.estimatedWaitingTimeMinutes = estimatedWaitingTimeMinutes;
+    }
 }


### PR DESCRIPTION
## 관련 티켓
- [[POS] 웨이팅 대기 시간 조정 API](https://www.notion.so/benkang/POS-API-1d783feabad3802c8224c2c31030261a?pvs=4)

## 주요 변경사항
- 웨이팅 대기 시간 조정 API 추가
  - 현재 활성화되어 있는 웨이팅 세팅의 예상 대기 시간 변경