### PR TITLE
[BE-38] [USER] 리뷰 목록 조회 API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/review/UserReviewController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/review/UserReviewController.java
@@ -1,0 +1,40 @@
+package im.fooding.app.controller.user.review;
+
+import im.fooding.app.dto.request.user.review.UserRetrieveReviewRequest;
+import im.fooding.app.dto.response.user.notification.UserNotificationResponse;
+import im.fooding.app.dto.response.user.review.UserReviewResponse;
+import im.fooding.app.service.user.review.UserReviewService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.global.UserInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/store")
+@Tag(name = "UserReviewController", description = "유저 리뷰 컨트롤러")
+@Slf4j
+public class UserReviewController {
+
+    private final UserReviewService userReviewService;
+
+    @GetMapping("{storeId}/reviews")
+    @Operation(summary = "리뷰 전체 조회", description = "별점순 / 최신순으로 리뷰를 조회합니다.")
+    public ApiResult<PageResponse<UserReviewResponse>> list(
+            @PathVariable Long storeId,
+            @Valid @RequestBody UserRetrieveReviewRequest request
+    ) {
+        return ApiResult.ok(userReviewService.list(storeId, request));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/review/UserRetrieveReviewRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/review/UserRetrieveReviewRequest.java
@@ -1,0 +1,32 @@
+package im.fooding.app.dto.request.user.review;
+
+import im.fooding.core.common.BasicSearch;
+import im.fooding.core.model.review.ReviewSortType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.query.SortDirection;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserRetrieveReviewRequest extends BasicSearch {
+
+    @NotNull
+    @Schema(
+            description = "정렬 타입",
+            example = "RECENT",
+            allowableValues = {"RECENT", "REVIEW"}
+    )
+    private ReviewSortType sortType;
+
+    @NotNull
+    @Schema(
+            description = "정렬 순서",
+            example = "ASCENDING",
+            allowableValues = {"ASCENDING", "DESCENDING"}
+    )
+    private SortDirection sortDirection;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/review/UserReviewResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/review/UserReviewResponse.java
@@ -1,0 +1,90 @@
+package im.fooding.app.dto.response.user.review;
+
+import im.fooding.core.model.review.Review;
+import im.fooding.core.model.review.ReviewImage;
+import im.fooding.core.model.review.ReviewScore;
+import im.fooding.core.model.review.VisitPurposeType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserReviewResponse {
+
+    @Schema(description = "리뷰 ID", example = "1")
+    private Long reviewId;
+
+    @Schema(description = "리뷰 작성자 닉네임", example = "홍길동")
+    private String nickname;
+
+    @Schema(description = "리뷰 작성자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private List<String> imageUrls;
+
+    @Schema(description = "리뷰 내용", example = "정말 맛있어요!")
+    private String content;
+
+    @Schema(description = "리뷰 평점", example = "4.5")
+    private ReviewScore score;
+
+    @Schema(description = "방문 목적", example = "데이트")
+    private VisitPurposeType purpose;
+
+    @Schema(description = "리뷰 좋아요 수", example = "10")
+    private Long likeCount;
+
+    @Schema(description = "리뷰 작성일", example = "2023-10-01")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "리뷰 수정일", example = "2023-10-02")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private UserReviewResponse(
+            Long reviewId,
+            String nickname,
+            List<String> imageUrls,
+            String content,
+            ReviewScore score,
+            VisitPurposeType purpose,
+            Long likeCount,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.reviewId = reviewId;
+        this.nickname = nickname;
+        this.imageUrls = imageUrls;
+        this.content = content;
+        this.score = score;
+        this.purpose = purpose;
+        this.likeCount = likeCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static UserReviewResponse of(
+            Review review,
+            List<ReviewImage> images,
+            Long likeCount
+    ) {
+        return UserReviewResponse.builder()
+                .reviewId(review.getId())
+                //.nickname(review.getWriter().getNickname())
+                .imageUrls(images.stream()
+                        .map(ReviewImage::getImageUrl)
+                        .collect(Collectors.toList()))
+                .content(review.getContent())
+                .score(review.getScore())
+                .purpose(review.getVisitPurposeType())
+                .likeCount(likeCount)
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/review/UserReviewService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/review/UserReviewService.java
@@ -1,0 +1,68 @@
+package im.fooding.app.service.user.review;
+
+import im.fooding.app.dto.request.user.review.UserRetrieveReviewRequest;
+import im.fooding.app.dto.response.user.review.UserReviewResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.review.Review;
+import im.fooding.core.model.review.ReviewImage;
+import im.fooding.core.service.review.ReviewImageService;
+import im.fooding.core.service.review.ReviewLikeService;
+import im.fooding.core.service.review.ReviewService;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserReviewService {
+
+    private final ReviewService reviewService;
+    private final ReviewImageService reviewImageService;
+    private final ReviewLikeService reviewLikeService;
+
+    public PageResponse<UserReviewResponse> list(Long storeId, UserRetrieveReviewRequest request) {
+        Pageable pageable = PageRequest.of(request.getPageNum() - 1, request.getPageSize());
+
+        Page<Review> reviewPage = reviewService.list(
+                storeId, pageable, request.getSortType(), request.getSortDirection()
+        );
+
+        List<Long> reviewIds = getReviewIds(reviewPage.getContent());
+
+        Map<Long, List<ReviewImage>> imageMap = getReviewImageMap(reviewIds);
+        Map<Long, Long> likeCountMap = getReviewLikeMap(reviewIds);
+
+        List<UserReviewResponse> content = reviewPage.getContent().stream()
+                .map(review -> UserReviewResponse.of(
+                        review,
+                        imageMap.getOrDefault(review.getId(), List.of()),
+                        likeCountMap.getOrDefault(review.getId(), 0L)
+                ))
+                .toList();
+
+        return PageResponse.of(content, PageInfo.of(reviewPage));
+    }
+
+    private List<Long> getReviewIds(List<Review> reviews) {
+        return reviews.stream()
+                .map(Review::getId)
+                .toList();
+    }
+
+    private Map<Long, List<ReviewImage>> getReviewImageMap(List<Long> reviewIds) {
+        return reviewImageService.list(reviewIds).stream()
+                .collect(Collectors.groupingBy(image -> image.getReview().getId()));
+    }
+
+    private Map<Long, Long> getReviewLikeMap(List<Long> reviewIds) {
+        return reviewLikeService.list(reviewIds);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/review/ReviewSortType.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/review/ReviewSortType.java
@@ -1,0 +1,6 @@
+package im.fooding.core.model.review;
+
+public enum ReviewSortType {
+    RECENT,
+    REVIEW;
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewLikeRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewLikeRepository.java
@@ -1,0 +1,15 @@
+package im.fooding.core.repository.review;
+
+import java.util.List;
+import java.util.Map;
+
+public interface QReviewLikeRepository {
+    /**
+     *
+     * @param reviewIds
+     * @return
+     */
+    Map<Long, Long> list(List<Long> reviewIds);
+
+
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewLikeRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewLikeRepositoryImpl.java
@@ -1,0 +1,32 @@
+package im.fooding.core.repository.review;
+
+import static im.fooding.core.model.review.QReviewLike.reviewLike;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class QReviewLikeRepositoryImpl implements QReviewLikeRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, Long> list(List<Long> reviewIds) {
+
+        return queryFactory
+                .select(reviewLike.review.id, reviewLike.count())
+                .from(reviewLike)
+                .where(reviewLike.review.id.in(reviewIds))
+                .groupBy(reviewLike.review.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(reviewLike.review.id),
+                        tuple -> Optional.ofNullable(tuple.get(reviewLike.count())).orElse(0L)
+                ));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewRepository.java
@@ -1,0 +1,17 @@
+package im.fooding.core.repository.review;
+
+import im.fooding.core.model.review.Review;
+import im.fooding.core.model.review.ReviewSortType;
+import org.hibernate.query.SortDirection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QReviewRepository {
+
+    Page<Review> list(
+            Long storeId,
+            Pageable pageable,
+            ReviewSortType sortType,
+            SortDirection sortDirection
+    );
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/review/QReviewRepositoryImpl.java
@@ -1,14 +1,15 @@
-package im.fooding.core.repository.store;
+package im.fooding.core.repository.review;
 
-import static com.querydsl.core.types.Order.*;
+import static com.querydsl.core.types.Order.ASC;
+import static com.querydsl.core.types.Order.DESC;
 import static im.fooding.core.model.review.QReview.review;
 import static im.fooding.core.model.store.QStore.store;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import im.fooding.core.model.store.Store;
-import im.fooding.core.model.store.StoreSortType;
+import im.fooding.core.model.review.Review;
+import im.fooding.core.model.review.ReviewSortType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.query.SortDirection;
@@ -17,39 +18,40 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
-public class QStoreRepositoryImpl implements QStoreRepository {
+public class QReviewRepositoryImpl implements QReviewRepository {
 
     private final JPAQueryFactory query;
 
     @Override
-    public Page<Store> list(
+    public Page<Review> list(
+            Long storeId,
             Pageable pageable,
-            StoreSortType sortType,
+            ReviewSortType sortType,
             SortDirection sortDirection
     ) {
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortType, sortDirection);
 
-        List<Store> content = query
-                .select(store)
-                .from(store)
-                .leftJoin(review).on(review.store.eq(store))
-                .groupBy(store.id)
+        List<Review> results = query
+                .select(review)
+                .from(review)
+                .where(review.store.id.eq(storeId))
                 .orderBy(orderSpecifier)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         JPQLQuery<Long> countQuery = query
-                .select(store.count())
+                .select(review.count())
+                .where(review.store.id.eq(storeId))
                 .from(store);
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
     }
 
-    private OrderSpecifier<?> getOrderSpecifier(StoreSortType sortType, SortDirection direction) {
+    private OrderSpecifier<?> getOrderSpecifier(ReviewSortType sortType, SortDirection direction) {
         return switch (sortType) {
             case REVIEW -> new OrderSpecifier<>
-                    (direction == SortDirection.ASCENDING ? ASC : DESC, review.count());
+                    (direction == SortDirection.ASCENDING ? ASC : DESC, review.score.total);
             case RECENT -> new OrderSpecifier<>
                     (direction == SortDirection.ASCENDING ? ASC : DESC, store.createdAt);
         };

--- a/fooding-core/src/main/java/im/fooding/core/repository/review/ReviewImageRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/review/ReviewImageRepository.java
@@ -1,0 +1,10 @@
+package im.fooding.core.repository.review;
+
+import im.fooding.core.model.review.ReviewImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+
+    List<ReviewImage> findAllByReviewIdIn(List<Long> reviewIds);
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/review/ReviewLikeRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/review/ReviewLikeRepository.java
@@ -1,0 +1,8 @@
+package im.fooding.core.repository.review;
+
+import im.fooding.core.model.review.ReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long>, QReviewLikeRepository {
+
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/review/ReviewRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/review/ReviewRepository.java
@@ -5,7 +5,7 @@ import im.fooding.core.model.store.Store;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, QReviewRepository {
 
     List<Review> findAllByStore(Store store);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/review/ReviewImageService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/review/ReviewImageService.java
@@ -1,0 +1,27 @@
+package im.fooding.core.service.review;
+
+import im.fooding.core.model.review.ReviewImage;
+import im.fooding.core.repository.review.ReviewImageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ReviewImageService {
+
+    private final ReviewImageRepository reviewImageRepository;
+
+    /**
+     * 리뷰 이미지 목록 조회
+     * @param reviewIds
+     * @return
+     */
+    public List<ReviewImage> list(List<Long> reviewIds) {
+        return reviewImageRepository.findAllByReviewIdIn(reviewIds);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/review/ReviewLikeService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/review/ReviewLikeService.java
@@ -1,0 +1,27 @@
+package im.fooding.core.service.review;
+
+import im.fooding.core.repository.review.ReviewLikeRepository;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ReviewLikeService {
+
+    private final ReviewLikeRepository reviewLikeRepository;
+
+    /**
+     *
+     * @param reviewIds
+     * @return
+     */
+    public Map<Long, Long> list(List<Long> reviewIds) {
+       return reviewLikeRepository.list(reviewIds);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/review/ReviewService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/review/ReviewService.java
@@ -1,13 +1,15 @@
 package im.fooding.core.service.review;
 
-import im.fooding.core.global.exception.ApiException;
-import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.review.Review;
+import im.fooding.core.model.review.ReviewSortType;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.repository.review.ReviewRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.query.SortDirection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+
+    /**
+     * * 리뷰 목록 조회
+     * @param storeId
+     * @param pageable
+     * @param sortType
+     * @param sortDirection
+     * @return
+     */
+    public Page<Review> list(
+            Long storeId,
+            Pageable pageable,
+            ReviewSortType sortType,
+            SortDirection sortDirection
+    ) {
+        return reviewRepository.list(storeId, pageable, sortType, sortDirection);
+    }
 
     public List<Review> list(Store store) {
         return reviewRepository.findAllByStore(store);


### PR DESCRIPTION
## 관련 티켓

https://www.notion.so/benkang/User-API-1d783feabad380b99fabf24e10b5af5e?pvs=4

## 구현 내용

* 별점순 / 최신순에 따라 정렬이 가능하도록 페이징 처리 
* 가게에 해당하는 리뷰를 조회 후, 리뷰 ID에 해당하는 리뷰 이미지를 모두 조회하여 DTO 반환 시에 조립하여 쿼리 발생 최소화
* 리뷰에 좋아요 기능이 구현되는지 기획에 따라 변경될 수 있으나, 레퍼런스에 존재하는 좋아요 기능을 바탕으로 해당 리뷰의 좋아요 개수 반환

## 리뷰 요구사항

* 앞서 설명드렸듯이 storeId에 해당하는 리뷰을 List로 받아온 뒤, 리스트에 담긴 리뷰ID를 참조하는 리뷰 이미지를 모두 조회하여 DTO를 반환하는 방식으로 쿼리를 최소화하도록 로직을 구현했습니다. 이와 관련하여 리뷰 남겨주시면 감사하겠습니다 :)