### PR TITLE
[BE-49] [CEO] 소식 조회 API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/storepost/CeoStorePostController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/storepost/CeoStorePostController.java
@@ -1,0 +1,31 @@
+package im.fooding.app.controller.ceo.storepost;
+
+import im.fooding.app.dto.response.ceo.storepost.StorePostResponse;
+import im.fooding.app.service.ceo.storepost.CeoStorePostService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ceo/storeposts")
+@Tag(name = "CeoStorePostController", description = "점주 소식 컨트롤러")
+@Slf4j
+public class CeoStorePostController {
+    private final CeoStorePostService ceoStorePostService;
+
+    @GetMapping
+    @Operation(summary = "특정 가게 소식 전체 조회")
+    public ApiResult<List<StorePostResponse>> list(@RequestParam Long storeId) {
+      List<StorePostResponse> storePosts = ceoStorePostService.getStorePosts(storeId);
+      return ApiResult.ok(storePosts);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/storepost/StorePostResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/storepost/StorePostResponse.java
@@ -1,0 +1,60 @@
+package im.fooding.app.dto.response.ceo.storepost;
+
+import im.fooding.core.model.store.StorePost;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class StorePostResponse {
+    @Schema(description = "소식 id", example = "1")
+    private long id;
+
+    @Schema(description = "소식 제목", example = "새로운 메뉴 출시 안내")
+    private String title;
+
+    @Schema(description = "소식 내용", example = "저희 가게에 새로운 메뉴가 출시되었습니다!")
+    private String content;
+
+    @Schema(description = "태그 목록", example = "[\"대표\", \"소식\"]")
+    private List<String> tags;
+
+    @Schema(description = "상단 고정 여부", example = "true")
+    private boolean isFixed;
+
+    @Schema(description = "등록 일자", example = "2025-04-25 12:00:00")
+    private LocalDateTime createdAt;
+
+    @Builder
+    private StorePostResponse(
+            Long id,
+            String title,
+            String content,
+            List<String> tags,
+            boolean isFixed,
+            LocalDateTime createdAt
+    ) {
+      this.id = id;
+      this.title = title;
+      this.content = content;
+      this.tags = tags;
+      this.isFixed = isFixed;
+      this.createdAt = createdAt;
+    }
+
+    public static StorePostResponse from(StorePost storePost) {
+      return new StorePostResponse(
+              storePost.getId(),
+              storePost.getTitle(),
+              storePost.getContent(),
+              storePost.getTags(),
+              storePost.isFixed(),
+              storePost.getCreatedAt()
+      );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/storepost/CeoStorePostService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/storepost/CeoStorePostService.java
@@ -1,0 +1,27 @@
+package im.fooding.app.service.ceo.storepost;
+
+import im.fooding.app.dto.response.ceo.storepost.StorePostResponse;
+import im.fooding.core.model.store.StorePost;
+import im.fooding.core.service.store.StorePostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class CeoStorePostService {
+    private final StorePostService storePostService;
+
+    public List<StorePostResponse> getStorePosts(Long storeId) {
+      List<StorePost> storePosts = storePostService.getStorePosts(storeId);
+      return storePosts.stream()
+              .map(StorePostResponse::from)
+              .collect(Collectors.toList());
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/StorePostRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/StorePostRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.store;
+
+import im.fooding.core.model.store.StorePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StorePostRepository extends JpaRepository<StorePost, Long> {
+    List<StorePost> findByStoreIdOrderByIsFixedDescCreatedAtDesc(Long storeId);
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StorePostService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StorePostService.java
@@ -1,0 +1,22 @@
+package im.fooding.core.service.store;
+
+import im.fooding.core.model.store.StorePost;
+import im.fooding.core.repository.store.StorePostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class StorePostService {
+    private final StorePostRepository storePostRepository;
+
+    public List<StorePost> getStorePosts(Long storeId) {
+      return storePostRepository.findByStoreIdOrderByIsFixedDescCreatedAtDesc(storeId);
+    }
+}


### PR DESCRIPTION
[BE-49]

#### 🧾 티켓
[[CEO] 소식 조회 API](https://www.notion.so/benkang/CEO-API-1d783feabad3807f8089cb3a8ee3b087?pvs=4)

##

#### 🔧 작업 내용

[ API ]
`CeoStorePostController`  -  가게 소식 조회 API 구현
`StorePostResponse` - 소식 응답 데이터 구현
`CeoStorePostService` - 소식 조회 후 응답 DTO로 변환

[ Core ]
`StorePostRepository` - 소식 조회 메서드 추가
`StorePostService` - 소식 조회 로직 처리