### PR TITLE
[BE-66] Notification Event, Handler 로 분리해서 슬랙 보내지도록 개선

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/event/NotificationCreatedEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/NotificationCreatedEvent.java
@@ -1,0 +1,15 @@
+package im.fooding.core.event;
+
+import im.fooding.core.model.notification.Notification;
+
+public class NotificationCreatedEvent {
+    private final Notification notification;
+
+    public NotificationCreatedEvent(Notification notification) {
+      this.notification = notification;
+    }
+
+    public Notification getNotification() {
+      return notification;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/event/NotificationCreatedEventListener.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/NotificationCreatedEventListener.java
@@ -1,0 +1,34 @@
+package im.fooding.core.event;
+
+import im.fooding.core.global.infra.slack.SlackClient;
+import im.fooding.core.model.notification.Notification;
+import im.fooding.core.model.notification.NotificationChannel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class NotificationCreatedEventListener {
+    private final SlackClient slackClient;
+
+    public NotificationCreatedEventListener(SlackClient slackClient) {
+      this.slackClient = slackClient;
+    }
+
+    @EventListener
+    public void sendSlackMessage(NotificationCreatedEvent event) {
+      Notification notification = event.getNotification();
+
+      if (notification.getChannel() == NotificationChannel.MESSAGE) {
+        String slackMessage = String.format(
+                "📢 알림 메시지 \n- 제목: %s\n- 내용: %s\n- 수신자: %s",
+                notification.getTitle(),
+                notification.getContent(),
+                notification.getDestination()
+        );
+        slackClient.sendNotificationMessage(slackMessage);
+        log.info("알림 슬랙 메시지 전송: {}", event.getNotification());
+      }
+    }
+}


### PR DESCRIPTION
[BE-66]

#### 🙆‍♀️티켓
[Notification Event, Handler 로 분리해서 슬랙 보내지도록 개선](https://www.notion.so/benkang/Notification-Event-Handler-1dd83feabad380aba764ef57fe36f6fa?pvs=4)

##

Notification Spring Event를 사용하여 슬랙 보내도록 리팩토링하였습니다

#### 🙆‍♀️상세 설명
[ API ]
`AdminNotificationService` -  알림 생성 후 `NotificationCreatedEvent` 이벤트를 퍼블리시하는 서비스 (메서드 수정)

[ Core ]
`NotificationCreatedEvent` - 알림 생성 시 발생하는 이벤트, 생성된 알림 정보가 담긴 데이터
`NotificationCreatedEventListener` - `NotificationCreatedEvent`를 처리하여 알림 정보를 Slack 등으로 전송하는 리스너

##

#### 🙆‍♀️테스트 결과
![Slack 테스트 성공](https://github.com/user-attachments/assets/7141f78c-6d3c-4081-bfc3-3580d05e5693)
