### PR TITLE
[BE-78] [CEO] 메뉴 카테고리 CRUD API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuCategoryController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuCategoryController.java
@@ -1,5 +1,6 @@
 package im.fooding.app.controller.ceo.menu;
 
+import im.fooding.app.dto.request.ceo.menu.CeoSortMenuCategoryRequest;
 import im.fooding.app.dto.response.ceo.menu.CeoMenuCategoryResponse;
 import im.fooding.app.service.ceo.menu.CeoMenuCategoryService;
 import im.fooding.core.common.ApiResult;
@@ -8,6 +9,7 @@ import im.fooding.core.model.menu.MenuCategory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -67,5 +70,14 @@ public class CeoMenuCategoryController {
             @PathVariable Long storeId
     ) {
         return ApiResult.ok(service.list(storeId));
+    }
+
+    @PostMapping("/menu-categorys/sort")
+    @Operation(summary = "메뉴 카테고리 정렬", description = "요청한 메뉴 카테고리 ID 순서대로 재정렬")
+    public ApiResult<Void> sort(
+            @Valid @RequestBody CeoSortMenuCategoryRequest request
+    ) {
+        service.sort(request);
+        return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuCategoryController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuCategoryController.java
@@ -1,0 +1,71 @@
+package im.fooding.app.controller.ceo.menu;
+
+import im.fooding.app.dto.response.ceo.menu.CeoMenuCategoryResponse;
+import im.fooding.app.service.ceo.menu.CeoMenuCategoryService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.global.UserInfo;
+import im.fooding.core.model.menu.MenuCategory;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ceo/stores")
+@Tag(name = "CeoMenuCategoryController", description = "점주 메뉴 카테고리 컨트롤러")
+public class CeoMenuCategoryController {
+
+    private final CeoMenuCategoryService service;
+
+    @PostMapping("/{storeId}/menu-categorys")
+    @Operation(summary = "메뉴 카테고리 생성", description = "메뉴에 대한 카테고리 생성")
+    public ApiResult<Long> create(
+            @PathVariable Long storeId,
+            @NotBlank(message = "카테고리 이름은 필수입니다.")
+            @RequestParam ("categoryName") String categoryName
+    ) {
+        return ApiResult.ok(service.create(storeId, categoryName));
+    }
+
+    @PatchMapping("/menu-categorys/{categoryId}")
+    @Operation(summary = "메뉴 카테고리 수정", description = "메뉴에 대한 카테고리 수정")
+    public ApiResult<Long> update(
+            @PathVariable Long categoryId,
+            @NotBlank(message = "카테고리 이름은 필수입니다.")
+            @RequestParam ("categoryName") String categoryName
+    ) {
+        return ApiResult.ok(service.update(categoryId, categoryName));
+    }
+
+    @DeleteMapping("/menu-categorys/{categoryId}")
+    @Operation(summary = "메뉴 카테고리 삭제", description = "메뉴에 대한 카테고리 삭제")
+    public ApiResult<Void> delete(
+            @AuthenticationPrincipal UserInfo userInfo,
+            @PathVariable Long categoryId
+    ) {
+        service.delete(userInfo.getId(), categoryId);
+        return ApiResult.ok();
+    }
+
+    @GetMapping("/{storeId}/menu-categorys")
+    @Operation(summary = "메뉴 카테고리 목록 조회", description = "메뉴에 대한 카테고리 목록 조회")
+    public ApiResult<List<CeoMenuCategoryResponse>> list(
+            @PathVariable Long storeId
+    ) {
+        return ApiResult.ok(service.list(storeId));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoSortMenuCategoryRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoSortMenuCategoryRequest.java
@@ -1,0 +1,17 @@
+package im.fooding.app.dto.request.ceo.menu;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CeoSortMenuCategoryRequest {
+
+    @NotEmpty
+    @Schema(description = "정렬된 순서로 나열된 메뉴 카테고리 ID", example = "5,3,4,2,1")
+    private List<Long> menuCategoryIds;
+
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuCategoryResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuCategoryResponse.java
@@ -1,0 +1,31 @@
+package im.fooding.app.dto.response.ceo.menu;
+
+import im.fooding.core.model.menu.MenuCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CeoMenuCategoryResponse {
+
+    @Schema(description = "메뉴 카테고리 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "메뉴 카테고리 이름", example = "식사류")
+    private String name;
+
+    @Builder
+    private CeoMenuCategoryResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static CeoMenuCategoryResponse of(MenuCategory menuCategory) {
+        return CeoMenuCategoryResponse.builder()
+                .id(menuCategory.getId())
+                .name(menuCategory.getName())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuCategoryResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuCategoryResponse.java
@@ -16,16 +16,21 @@ public class CeoMenuCategoryResponse {
     @Schema(description = "메뉴 카테고리 이름", example = "식사류")
     private String name;
 
+    @Schema(description = "메뉴 카테고리 정렬 순서", example = "1")
+    private int sortOrder;
+
     @Builder
-    private CeoMenuCategoryResponse(Long id, String name) {
+    private CeoMenuCategoryResponse(Long id, String name, int sortOrder) {
         this.id = id;
         this.name = name;
+        this.sortOrder = sortOrder;
     }
 
     public static CeoMenuCategoryResponse of(MenuCategory menuCategory) {
         return CeoMenuCategoryResponse.builder()
                 .id(menuCategory.getId())
                 .name(menuCategory.getName())
+                .sortOrder(menuCategory.getSortOrder())
                 .build();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/menu/CeoMenuCategoryService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/menu/CeoMenuCategoryService.java
@@ -1,0 +1,39 @@
+package im.fooding.app.service.ceo.menu;
+
+import im.fooding.app.dto.response.ceo.menu.CeoMenuCategoryResponse;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.service.menu.MenuCategoryService;
+import im.fooding.core.service.store.StoreService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CeoMenuCategoryService {
+
+    private final MenuCategoryService menuCategoryService;
+    private final StoreService storeService;
+
+    public Long create(Long storeId, String categoryName) {
+        Store store = storeService.findById(storeId);
+        int sortOrder = menuCategoryService.getSortOrder(storeId);
+
+        return menuCategoryService.create(store, categoryName, sortOrder);
+    }
+
+    public Long update(Long categoryId, String categoryName) {
+        return menuCategoryService.update(categoryId, categoryName);
+    }
+
+    public void delete(Long categoryId, Long userId) {
+        menuCategoryService.delete(userId, categoryId);
+    }
+
+    public List<CeoMenuCategoryResponse> list(Long storeId) {
+        return menuCategoryService.list(storeId)
+                .stream()
+                .map(CeoMenuCategoryResponse::of)
+                .toList();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/menu/CeoMenuCategoryService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/menu/CeoMenuCategoryService.java
@@ -1,5 +1,6 @@
 package im.fooding.app.service.ceo.menu;
 
+import im.fooding.app.dto.request.ceo.menu.CeoSortMenuCategoryRequest;
 import im.fooding.app.dto.response.ceo.menu.CeoMenuCategoryResponse;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.service.menu.MenuCategoryService;
@@ -35,5 +36,9 @@ public class CeoMenuCategoryService {
                 .stream()
                 .map(CeoMenuCategoryResponse::of)
                 .toList();
+    }
+
+    public void sort(CeoSortMenuCategoryRequest request) {
+        menuCategoryService.sort(request.getMenuCategoryIds());
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -50,7 +50,10 @@ public enum ErrorCode {
     // 알림
     NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "5000", "등록된 알림이 없습니다."),
     USER_NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "5001", "사용자 알림을 찾을 수 없습니다."),
-    USER_NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "5002", "해당 알림에 접근할 권한이 없습니다.");
+    USER_NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "5002", "해당 알림에 접근할 권한이 없습니다."),
+
+    // 메뉴
+    MENUCATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "6000", "등록된 메뉴 카테고리가 없습니다.");
 
     private final HttpStatus status;
 

--- a/fooding-core/src/main/java/im/fooding/core/model/menu/MenuCategory.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/MenuCategory.java
@@ -56,4 +56,8 @@ public class MenuCategory extends BaseEntity {
     public void updateCategoryName(String categoryName) {
         this.name = categoryName;
     }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/menu/MenuCategory.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/MenuCategory.java
@@ -53,9 +53,7 @@ public class MenuCategory extends BaseEntity {
         this.sortOrder = sortOrder;
     }
 
-    public void update(String name, String description, int sortOrder) {
-        this.name = name;
-        this.description = description;
-        this.sortOrder = sortOrder;
+    public void updateCategoryName(String categoryName) {
+        this.name = categoryName;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuCategoryRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuCategoryRepository.java
@@ -4,7 +4,7 @@ import im.fooding.core.model.menu.MenuCategory;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MenuCategoryRepository extends JpaRepository<MenuCategory, Long> {
+public interface MenuCategoryRepository extends JpaRepository<MenuCategory, Long>, QMenuCategoryRepository {
 
     List<MenuCategory> findAllByStoreIdAndDeletedFalse(long storeId);
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuCategoryRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuCategoryRepository.java
@@ -1,0 +1,6 @@
+package im.fooding.core.repository.menu;
+
+public interface QMenuCategoryRepository {
+
+    int getMaxSortOrder(Long storeId);
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuCategoryRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuCategoryRepositoryImpl.java
@@ -1,0 +1,26 @@
+package im.fooding.core.repository.menu;
+
+import static im.fooding.core.model.menu.QMenuCategory.menuCategory;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class QMenuCategoryRepositoryImpl implements QMenuCategoryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public int getMaxSortOrder(Long storeId) {
+        Integer maxSortOrder = queryFactory
+                .select(menuCategory.sortOrder.max())
+                .from(menuCategory)
+                .where(
+                        menuCategory.store.id.eq(storeId),
+                        menuCategory.deleted.isFalse()
+                )
+                .fetchOne();
+
+        return maxSortOrder != null ? maxSortOrder : 0;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
@@ -42,9 +42,7 @@ public class MenuCategoryService {
      */
     @Transactional
     public Long update(Long categoryId, String categoryName) {
-        MenuCategory menuCategory = menuCategoryRepository.findById(categoryId).filter(it -> !it.isDeleted())
-                .orElseThrow(() -> new ApiException(ErrorCode.MENUCATEGORY_NOT_FOUND));
-
+        MenuCategory menuCategory = findByid(categoryId);
         menuCategory.updateCategoryName(categoryName);
         return menuCategory.getId();
     }
@@ -57,8 +55,7 @@ public class MenuCategoryService {
      */
     @Transactional
     public void delete(Long userId, Long categoryId) {
-        MenuCategory menuCategory = menuCategoryRepository.findById(categoryId).filter(it -> !it.isDeleted())
-                .orElseThrow(() -> new ApiException(ErrorCode.MENUCATEGORY_NOT_FOUND));
+        MenuCategory menuCategory = findByid(categoryId);
         menuCategory.delete(userId);
     }
 
@@ -73,11 +70,31 @@ public class MenuCategoryService {
     }
 
     /**
+     * 메뉴 카테고리 정렬
+     *
+     * @param menuCategoryIds
+     */
+    @Transactional
+    public void sort(List<Long> menuCategoryIds) {
+        int sortOrder = 1;
+        for (Long id : menuCategoryIds) {
+            MenuCategory menuCategory = findByid(id);
+            menuCategory.updateSortOrder(sortOrder++);
+        }
+    }
+
+    /**
      * 메뉴 카테고리 최대 정렬 순서 조회
      *
      * @param storeId
      */
     public int getSortOrder(Long storeId) {
         return menuCategoryRepository.getMaxSortOrder(storeId);
+    }
+
+    private MenuCategory findByid(Long id) {
+        return menuCategoryRepository.findById(id)
+                .filter(it -> !it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.MENUCATEGORY_NOT_FOUND));
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuCategoryService.java
@@ -1,6 +1,9 @@
 package im.fooding.core.service.menu;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.menu.MenuCategory;
+import im.fooding.core.model.store.Store;
 import im.fooding.core.repository.menu.MenuCategoryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,50 @@ public class MenuCategoryService {
 
     private final MenuCategoryRepository menuCategoryRepository;
 
+    /**
+     * 메뉴 카테고리 생성
+     *
+     * @param store
+     * @param categoryName
+     * @param sortOrder
+     */
+    @Transactional
+    public Long create(Store store, String categoryName, int sortOrder) {
+        MenuCategory menuCategory = MenuCategory.builder()
+                .store(store)
+                .name(categoryName)
+                .sortOrder(sortOrder)
+                .build();
+        return menuCategoryRepository.save(menuCategory).getId();
+    }
+
+    /**
+     * 메뉴 카테고리 수정
+     *
+     * @param categoryId
+     * @param categoryName
+     */
+    @Transactional
+    public Long update(Long categoryId, String categoryName) {
+        MenuCategory menuCategory = menuCategoryRepository.findById(categoryId).filter(it -> !it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.MENUCATEGORY_NOT_FOUND));
+
+        menuCategory.updateCategoryName(categoryName);
+        return menuCategory.getId();
+    }
+
+    /**
+     * 메뉴 카테고리 삭제
+     *
+     * @param userId
+     * @param categoryId
+     */
+    @Transactional
+    public void delete(Long userId, Long categoryId) {
+        MenuCategory menuCategory = menuCategoryRepository.findById(categoryId).filter(it -> !it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.MENUCATEGORY_NOT_FOUND));
+        menuCategory.delete(userId);
+    }
 
     /**
      * 메뉴 카테고리 목록 조회
@@ -23,5 +70,14 @@ public class MenuCategoryService {
      */
     public List<MenuCategory> list(long storeId) {
         return menuCategoryRepository.findAllByStoreIdAndDeletedFalse(storeId);
+    }
+
+    /**
+     * 메뉴 카테고리 최대 정렬 순서 조회
+     *
+     * @param storeId
+     */
+    public int getSortOrder(Long storeId) {
+        return menuCategoryRepository.getMaxSortOrder(storeId);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -1,5 +1,7 @@
 package im.fooding.core.service.store;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreSortType;
 import im.fooding.core.repository.store.StoreRepository;
@@ -33,5 +35,15 @@ public class StoreService {
             SortDirection sortDirection
     ) {
         return storeRepository.list(pageable, sortType, sortDirection);
+    }
+
+    /**
+     * 가게 아이디로 조회
+     * @param storeId
+     * @return
+     */
+    public Store findById(long storeId) {
+        return storeRepository.findById(storeId).filter(it -> !it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.STORE_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 관련 티켓

https://www.notion.so/benkang/CEO-CRUD-API-1e283feabad3808bb64dc231d4a26080?pvs=4

## 구현 내용

- 메뉴 카테고리 생성
   - 카테고리 생성 시, sortOrder의 최댓값을 조회하여 다음 정렬순으로 배치 
- 메뉴 카테고리 목록 조회
- 메뉴 카테고리 수정
- 메뉴 카테고리 삭제
- 메뉴 카테고리 순서 정렬
   
## 참고 사항

* 카테고리 생성, 수정에 대해 반환값을 해당 엔티티의 ID를 반환하는 것으로 하였습니다. 

*  정렬 API 로직
    * `CeoSortMenuCategoryRequest` 에 입력된 메뉴 카테고리 ID 순서대로 재정렬합니다.
    *  해당 방식으로 구현한 이유는 메뉴 카테고리의 경우, 갯수가 많지 않기에 로직 재정렬하는 시간 복잡도가 오래 걸리지 않다고 판단하여 순서 정렬에 오류 방지 및 구현 복잡도를 중점으로 구현을 생각하여 다음과 같이 구현하였습니다.
    * 추가로 이에 대해 벌크 업데이트를 통해 쿼리를 한 번에 처리할 계획이나 이 부분은 논의가 필요할 거 같습니다.  
