### PR TITLE
[BE-85] [ADMIN] 웨이팅 관련 도메인 CRUD API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/waiting/AdminWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/waiting/AdminWaitingController.java
@@ -1,0 +1,80 @@
+package im.fooding.app.controller.admin.waiting;
+
+import im.fooding.app.dto.request.admin.waiting.AdminWaitingCreateRequest;
+import im.fooding.app.dto.request.admin.waiting.AdminWaitingUpdateRequest;
+import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.app.service.admin.waiting.AdminWaitingService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.BasicSearch;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.global.UserInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/waitings")
+@Tag(name = "AdminWaitingController", description = "웨이팅 관리 컨트롤러")
+@Slf4j
+public class AdminWaitingController {
+
+    private final AdminWaitingService adminWaitingService;
+
+    @PostMapping
+    @Operation(summary = "웨이팅 생성")
+    public ApiResult<WaitingResponse> createWaiting(
+            @RequestBody @Valid AdminWaitingCreateRequest request
+    ) {
+        WaitingResponse response = adminWaitingService.createWaiting(request);
+        return ApiResult.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "웨이팅 조회")
+    public ApiResult<WaitingResponse> getWaiting(
+            @PathVariable long id
+    ) {
+        return ApiResult.ok(adminWaitingService.getWaiting(id));
+    }
+
+    @GetMapping
+    @Operation(summary = "웨이팅 조회(page)")
+    public ApiResult<PageResponse<WaitingResponse>> getWaitingList(
+            @Parameter(description = "검색 및 페이징 조건")
+            @ModelAttribute BasicSearch search
+    ) {
+        return ApiResult.ok(adminWaitingService.getWaitingList(search));
+    }
+
+    @PutMapping
+    @Operation(summary = "웨이팅 수정")
+    public ApiResult<WaitingResponse> UpdateWaiting(
+            @RequestBody AdminWaitingUpdateRequest request
+    ) {
+        return ApiResult.ok(adminWaitingService.updateWaiting(request));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "웨이팅 제거")
+    public ApiResult<Void> deleteWaiting(
+            @AuthenticationPrincipal UserInfo userInfo,
+            @PathVariable long id
+    ) {
+        adminWaitingService.deleteWaiting(id, userInfo.getId());
+        return ApiResult.ok();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/AppWaitingController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
-import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.core.common.PageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +32,7 @@ public class AppWaitingController {
 
     @GetMapping("/{id}/requests")
     @Operation(summary = "웨이팅 목록 조회")
-    ApiResult<PageResponse<WaitingResponse>> list(
+    ApiResult<PageResponse<StoreWaitingResponse>> list(
             @Parameter(description = "웨이팅 id", example = "1")
             @PathVariable long id,
 

--- a/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/waiting/PosWaitingController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
-import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.core.common.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +32,7 @@ public class PosWaitingController {
 
     @GetMapping("/{id}/requests")
     @Operation(summary = "웨이팅 목록 조회")
-    ApiResult<PageResponse<WaitingResponse>> list(
+    ApiResult<PageResponse<StoreWaitingResponse>> list(
             @Parameter(description = "웨이팅 id", example = "1")
             @PathVariable long id,
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/waiting/AdminWaitingCreateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/waiting/AdminWaitingCreateRequest.java
@@ -1,0 +1,20 @@
+package im.fooding.app.dto.request.admin.waiting;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AdminWaitingCreateRequest(
+
+        @Schema(description = "가게 아이디", example = "1")
+        @NotNull
+        Long storeId,
+
+        @Schema(description = "웨이팅 상태 (WAITING_OPEN, IMMEDIATE_ENTRY, PAUSED, WAITING_CLOSE)", example = "WAITING_OPEN")
+        @NotBlank
+        String status
+) {
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/waiting/AdminWaitingUpdateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/waiting/AdminWaitingUpdateRequest.java
@@ -1,0 +1,31 @@
+package im.fooding.app.dto.request.admin.waiting;
+
+import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.core.model.waiting.Waiting;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminWaitingUpdateRequest(
+
+        @Schema(description = "ID", example = "1")
+        @NotBlank
+        long id,
+
+        @Schema(description = "가게 아이디", example = "1")
+        @NotNull
+        long storeId,
+
+        @Schema(description = "웨이팅 상태 (WAITING_OPEN, IMMEDIATE_ENTRY, PAUSED, WAITING_CLOSE)", example = "WAITING_OPEN")
+        @NotBlank
+        String status
+) {
+
+    public static WaitingResponse from(Waiting waiting) {
+        return new WaitingResponse(
+                waiting.getId(),
+                waiting.getStoreId(),
+                waiting.getStatusValue()
+        );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/waiting/WaitingResponse.java
@@ -1,48 +1,29 @@
 package im.fooding.app.dto.response.waiting;
 
-import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.Waiting;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record WaitingResponse(
-        @Schema(description = "id", example = "1")
+
+        @Schema(description = "ID", example = "1")
         long id,
 
-        @Schema(description = "가게 id", example = "1")
+        @Schema(description = "가게 아이디", example = "1")
+        @NotNull
         long storeId,
 
-        @Schema(description = "유저 정보")
-        WaitingUserResponse user,
-
-        @Schema(description = "호출 번호", example = "1")
-        int callNumber,
-
-        @Schema(description = "등록 수단", example = "IN_PERSON")
-        String channel,
-
-        @Schema(description = "필요한 유아용 의자 개수", example = "1")
-        int infantChairCount,
-
-        @Schema(description = "유아 입장 인원수", example = "1")
-        int infantCount,
-
-        @Schema(description = "성인 입장 인원수", example = "1")
-        int adultCount,
-
-        @Schema(description = "메모", example = "this is memo.")
-        String memo
+        @Schema(description = "웨이팅 상태 (WAITING_OPEN, IMMEDIATE_ENTRY, PAUSED, WAITING_CLOSE)", example = "WAITING_OPEN")
+        @NotBlank
+        String status
 ) {
 
-    public static WaitingResponse from(StoreWaiting storeWaiting) {
+    public static WaitingResponse from(Waiting waiting) {
         return new WaitingResponse(
-                storeWaiting.getId(),
-                storeWaiting.getStoreId(),
-                WaitingUserResponse.from(storeWaiting.getUser()),
-                storeWaiting.getCallNumber(),
-                storeWaiting.getChannelValue(),
-                storeWaiting.getInfantChairCount(),
-                storeWaiting.getInfantCount(),
-                storeWaiting.getAdultCount(),
-                storeWaiting.getMemo()
+                waiting.getId(),
+                waiting.getStoreId(),
+                waiting.getStatusValue()
         );
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/waiting/AdminWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/waiting/AdminWaitingService.java
@@ -1,0 +1,60 @@
+package im.fooding.app.service.admin.waiting;
+
+
+import im.fooding.app.dto.request.admin.waiting.AdminWaitingCreateRequest;
+import im.fooding.app.dto.request.admin.waiting.AdminWaitingUpdateRequest;
+import im.fooding.app.dto.response.waiting.WaitingResponse;
+import im.fooding.core.common.BasicSearch;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.Waiting;
+import im.fooding.core.model.waiting.WaitingStatus;
+import im.fooding.core.service.waiting.WaitingService;
+import im.fooding.core.service.store.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminWaitingService {
+
+    private final WaitingService waitingService;
+    private final StoreService storeService;
+
+    @Transactional
+    public WaitingResponse createWaiting(AdminWaitingCreateRequest request) {
+        Store store = storeService.get(request.storeId());
+        WaitingStatus status = WaitingStatus.of(request.status());
+
+        Waiting waiting = waitingService.create(store, status);
+
+        return WaitingResponse.from(waiting);
+    }
+
+    public WaitingResponse getWaiting(long id) {
+        return WaitingResponse.from(waitingService.getById(id));
+    }
+
+    public PageResponse<WaitingResponse> getWaitingList(BasicSearch search) {
+        Page<Waiting> waitings = waitingService.getList(search.getPageable());
+        return PageResponse.of(waitings.stream().map(WaitingResponse::from).toList(), PageInfo.of(waitings));
+    }
+
+    @Transactional
+    public WaitingResponse updateWaiting(AdminWaitingUpdateRequest request) {
+        long id = request.id();
+        Store store = storeService.get(request.storeId());
+        WaitingStatus status = WaitingStatus.of(request.status());
+
+        return WaitingResponse.from(waitingService.update(id, store, status));
+    }
+
+    @Transactional
+    public void deleteWaiting(long id, long deletedBy) {
+        waitingService.delete(id, deletedBy);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/AppWaitingApplicationService.java
@@ -21,7 +21,6 @@ import im.fooding.app.dto.response.waiting.StoreWaitingResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
-import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
@@ -47,7 +46,7 @@ public class AppWaitingApplicationService {
         return StoreWaitingResponse.from(storeWaitingService.get(id));
     }
 
-    public PageResponse<WaitingResponse> list(long id, WaitingListRequest request) {
+    public PageResponse<StoreWaitingResponse> list(long id, WaitingListRequest request) {
 
         Waiting waiting = waitingService.getById(id);
 
@@ -57,9 +56,9 @@ public class AppWaitingApplicationService {
                 .build();
         Page<StoreWaiting> storeWaitings = storeWaitingService.list(storeWaitingFilter, request.pageable());
 
-        List<WaitingResponse> list = storeWaitings.getContent()
+        List<StoreWaitingResponse> list = storeWaitings.getContent()
                 .stream()
-                .map(WaitingResponse::from)
+                .map(StoreWaitingResponse::from)
                 .toList();
 
         return PageResponse.of(list, PageInfo.of(storeWaitings));

--- a/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/waiting/PosWaitingService.java
@@ -2,7 +2,6 @@ package im.fooding.app.service.waiting;
 
 import im.fooding.app.dto.request.waiting.PosUpdateWaitingContactInfoRequest;
 import im.fooding.app.dto.request.waiting.WaitingListRequest;
-import im.fooding.app.dto.response.waiting.WaitingResponse;
 import im.fooding.app.service.user.notification.UserNotificationApplicationService;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
@@ -47,7 +46,7 @@ public class PosWaitingService {
         return StoreWaitingResponse.from(storeWaitingService.get(id));
     }
 
-    public PageResponse<WaitingResponse> list(long id, WaitingListRequest request) {
+    public PageResponse<StoreWaitingResponse> list(long id, WaitingListRequest request) {
 
         Waiting waiting = waitingService.getById(id);
 
@@ -57,9 +56,9 @@ public class PosWaitingService {
                 .build();
         Page<StoreWaiting> storeWaitings = storeWaitingService.list(storeWaitingFilter, request.pageable());
 
-        List<WaitingResponse> list = storeWaitings.getContent()
+        List<StoreWaitingResponse> list = storeWaitings.getContent()
                 .stream()
-                .map(WaitingResponse::from)
+                .map(StoreWaitingResponse::from)
                 .toList();
 
         return PageResponse.of(list, PageInfo.of(storeWaitings));

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     STORE_WAITING_ALREADY_WAITING(HttpStatus.BAD_REQUEST, "3006", "이미 가게 웨이팅 상태입니다."),
     STORE_WAITING_ILLEGAL_STATE_SEAT(HttpStatus.BAD_REQUEST, "3007", "착성 가능한 웨이팅 상태가 아닙니다."),
     WAITING_STATUS_STORE_WAITING_EXIST(HttpStatus.BAD_REQUEST, "3008", "남아있는 대기중인 웨이팅이 존재합니다."),
+    DUPLICATED_STORE_BY_WAITING(HttpStatus.BAD_REQUEST, "3009", "가게와 관련된 웨이팅 정보가 존재합니다."),
 
     // 디바이스
     DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "7000", "등록된 디바이스가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/Waiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/Waiting.java
@@ -3,8 +3,6 @@ package im.fooding.core.model.waiting;
 import im.fooding.core.model.BaseEntity;
 import im.fooding.core.model.store.Store;
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,5 +43,18 @@ public class Waiting extends BaseEntity {
 
     public boolean isOpen() {
         return status == WaitingStatus.WAITING_OPEN;
+    }
+
+    public String getStatusValue() {
+        return status.getValue();
+    }
+
+    public long getStoreId() {
+        return store.getId();
+    }
+
+    public void update(Store store, WaitingStatus status) {
+        this.store = store;
+        this.status = status;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingRepository.java
@@ -3,9 +3,15 @@ package im.fooding.core.repository.waiting;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.Waiting;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     Optional<Waiting> findByStore(Store store);
+
+    boolean existsByStore(Store store);
+
+    Page<Waiting> findAllByDeletedFalse(Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -1,5 +1,7 @@
 package im.fooding.core.service.store;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreSortType;
 import im.fooding.core.repository.store.StoreRepository;
@@ -33,5 +35,11 @@ public class StoreService {
             SortDirection sortDirection
     ) {
         return storeRepository.list(pageable, sortType, sortDirection);
+    }
+
+    public Store get(long id) {
+        return storeRepository.findById(id)
+                .filter(it -> !it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.STORE_NOT_FOUND));
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingService.java
@@ -2,11 +2,14 @@ package im.fooding.core.service.waiting;
 
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingStatus;
 import im.fooding.core.repository.waiting.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,5 +30,35 @@ public class WaitingService {
     public void updateStatus(long id, WaitingStatus status) {
         Waiting waiting = getById(id);
         waiting.updateStatus(status);
+    }
+
+    @Transactional
+    public Waiting create(Store store, WaitingStatus status) {
+        if (waitingRepository.existsByStore(store)) {
+            throw new ApiException(ErrorCode.DUPLICATED_STORE_BY_WAITING);
+        }
+        Waiting waiting = new Waiting(store, status);
+
+        return waitingRepository.save(waiting);
+    }
+
+    public Page<Waiting> getList(Pageable pageable) {
+        return waitingRepository.findAllByDeletedFalse(pageable);
+    }
+
+    @Transactional
+    public Waiting update(long id, Store store, WaitingStatus status) {
+        Waiting waiting = getById(id);
+
+        waiting.update(store, status);
+
+        return waiting;
+    }
+
+    @Transactional
+    public void delete(long id, long deletedBy) {
+        Waiting waiting = getById(id);
+
+        waiting.delete(deletedBy);
     }
 }


### PR DESCRIPTION
## 관련 티켓
[[ADMIN] 웨이팅 관련 도메인 CRUD API](https://www.notion.so/benkang/ADMIN-CRUD-API-1e483feabad380ce99aec8948ac41da8?pvs=4)

## 주요 변경사항
- [x] Waiting CRUD 추가
- [ ] StoreWaiting CRUD 추가
- [ ] WaitingLog CRUD 추가
- [ ] WaitingSetting CRUD 추가
- [ ] WaitingUser CRUD 추가

## 리뷰 사항
현재 ADMIN 웨이팅 관련 도메인 CRUD 개발 중 웨이팅 CRUD만 개발 진행된 상태입니다.
메서드명, 조회 등 리뷰를 받아보고 이어 리뷰 진행하려 합니다.
모든 도메인의 CRUD 흐름은 비슷할 것 같아 우선 리뷰 받아보려 PR 열었습니다!