### PR TITLE
[BE-50] [BE-52] [BE-53] [CEO] 소식 작성, 수정, 삭제 API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/storepost/CeoStorePostController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/storepost/CeoStorePostController.java
@@ -1,16 +1,18 @@
 package im.fooding.app.controller.ceo.storepost;
 
+import im.fooding.app.dto.request.ceo.storepost.CeoCreateStorePostRequest;
+import im.fooding.app.dto.request.ceo.storepost.CeoUpdateStorePostRequest;
 import im.fooding.app.dto.response.ceo.storepost.StorePostResponse;
 import im.fooding.app.service.ceo.storepost.CeoStorePostService;
 import im.fooding.core.common.ApiResult;
+import im.fooding.core.global.UserInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,5 +29,27 @@ public class CeoStorePostController {
     public ApiResult<List<StorePostResponse>> list(@RequestParam Long storeId) {
       List<StorePostResponse> storePosts = ceoStorePostService.list(storeId);
       return ApiResult.ok(storePosts);
+    }
+
+    @PostMapping
+    @Operation(summary = "소식 생성")
+    public ApiResult<Long> create(@RequestBody @Valid CeoCreateStorePostRequest request) {
+      Long id = ceoStorePostService.create(request);
+      return ApiResult.ok(id);
+    }
+
+    @PutMapping("/{storePostId}")
+    @Operation(summary = "소식 수정")
+    public ApiResult<Void> update(@PathVariable Long storePostId,
+                                  @RequestBody @Valid CeoUpdateStorePostRequest request) {
+      ceoStorePostService.update(storePostId, request);
+      return ApiResult.ok();
+    }
+
+    @DeleteMapping("/{storePostId}")
+    @Operation(summary = "소식 삭제")
+    public ApiResult<Void> delete(@PathVariable Long storePostId, @AuthenticationPrincipal UserInfo userInfo) {
+      ceoStorePostService.delete(storePostId, userInfo.getId());
+      return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/storepost/CeoCreateStorePostRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/storepost/CeoCreateStorePostRequest.java
@@ -1,0 +1,33 @@
+package im.fooding.app.dto.request.ceo.storepost;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CeoCreateStorePostRequest {
+    @NotNull
+    @Schema(description = "가게 ID", example = "1")
+    private Long storeId;
+
+    @NotBlank(message = "제목을 입력해주세요.")
+    @Schema(description = "소식 제목", example = "신메뉴 출시 안내")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    @Schema(description = "소식 내용", example = "새로운 디저트가 추가되었습니다!")
+    private String content;
+
+    @Schema(description = "태그 목록", example = "[\"소식\", \"이벤트\"]")
+    private List<String> tags;
+
+    @NotNull
+    @Schema(description = "상단 고정 여부", example = "true")
+    private Boolean isFixed;
+}
+

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/storepost/CeoUpdateStorePostRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/storepost/CeoUpdateStorePostRequest.java
@@ -1,0 +1,28 @@
+package im.fooding.app.dto.request.ceo.storepost;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CeoUpdateStorePostRequest {
+    @NotBlank(message = "제목을 입력해주세요.")
+    @Schema(description = "소식 제목", example = "신메뉴 출시 일정 변경 안내")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    @Schema(description = "소식 내용", example = "출시 일정이 변경되었습니다.")
+    private String content;
+
+    @Schema(description = "태그 목록", example = "[\"대표\", \"소식\"]")
+    private List<String> tags;
+
+    @NotNull
+    @Schema(description = "상단 고정 여부", example = "false")
+    private Boolean isFixed;
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/storepost/CeoStorePostService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/storepost/CeoStorePostService.java
@@ -1,8 +1,12 @@
 package im.fooding.app.service.ceo.storepost;
 
+import im.fooding.app.dto.request.ceo.storepost.CeoCreateStorePostRequest;
+import im.fooding.app.dto.request.ceo.storepost.CeoUpdateStorePostRequest;
 import im.fooding.app.dto.response.ceo.storepost.StorePostResponse;
+import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StorePost;
 import im.fooding.core.service.store.StorePostService;
+import im.fooding.core.service.store.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,11 +21,40 @@ import java.util.stream.Collectors;
 @Slf4j
 public class CeoStorePostService {
     private final StorePostService storePostService;
+    private final StoreService storeService;
 
     public List<StorePostResponse> list(Long storeId) {
       List<StorePost> storePosts = storePostService.list(storeId);
       return storePosts.stream()
               .map(StorePostResponse::from)
               .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Long create(CeoCreateStorePostRequest request) {
+      Store store = storeService.findById(request.getStoreId());
+
+      StorePost storePost = StorePost.builder()
+              .store(store)
+              .title(request.getTitle())
+              .content(request.getContent())
+              .tags(request.getTags())
+              .isFixed(request.getIsFixed())
+              .build();
+
+      return storePostService.create(storePost).getId();
+
+    }
+
+    @Transactional
+    public void update(Long storePostId, CeoUpdateStorePostRequest request) {
+      StorePost storePost = storePostService.findById(storePostId);
+      storePostService.update(storePost, request.getTitle(), request.getContent(), request.getTags(), request.getIsFixed());
+
+    }
+
+    @Transactional
+    public void delete(Long storePostId, Long deletedBy) {
+      storePostService.delete(storePostId, deletedBy);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/event/NotificationEventListener.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/NotificationEventListener.java
@@ -8,10 +8,10 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class NotificationCreatedEventListener {
+public class NotificationEventListener {
     private final SlackClient slackClient;
 
-    public NotificationCreatedEventListener(SlackClient slackClient) {
+    public NotificationEventListener(SlackClient slackClient) {
       this.slackClient = slackClient;
     }
 

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2000", "등록된 가게 정보가 없습니다."),
     STORE_SERVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2100", "등록된 가게 서비스가 없습니다."),
     STORE_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2001", "등록된 가게 이미지가 없습니다."),
+    STORE_POST_NOT_FOUND(HttpStatus.BAD_REQUEST,"2200", "등록된 가게 소식이 없습니다."),
 
 
     // 웨이팅

--- a/fooding-core/src/main/java/im/fooding/core/service/notification/UserNotificationService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/notification/UserNotificationService.java
@@ -24,6 +24,7 @@ public class UserNotificationService {
 
   public UserNotification getNotification(Long userId, Long notificationId) {
     UserNotification notification = userNotificationRepository.findById(notificationId)
+            .filter(it -> !it.isDeleted())
             .orElseThrow(() -> new ApiException(ErrorCode.USER_NOTIFICATION_NOT_FOUND));
 
     if (!notification.getUser().getId().equals(userId)) {

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StorePostService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StorePostService.java
@@ -1,5 +1,7 @@
 package im.fooding.core.service.store;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.store.StorePost;
 import im.fooding.core.repository.store.StorePostRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,4 +21,26 @@ public class StorePostService {
     public List<StorePost> list(Long storeId) {
       return storePostRepository.findByStoreIdOrderByIsFixedDescUpdatedAtDesc(storeId);
     }
+
+    public StorePost findById(Long id) {
+      return storePostRepository.findById(id)
+              .filter(it -> !it.isDeleted())
+              .orElseThrow(() -> new ApiException(ErrorCode.STORE_POST_NOT_FOUND));
+    }
+
+    @Transactional
+    public StorePost create(StorePost storePost) {
+      return storePostRepository.save(storePost);
+    }
+
+    @Transactional
+    public void update(StorePost storePost, String title, String content, List<String> tags, boolean isFixed) {
+      storePost.update(title, content, tags, isFixed);
+    }
+
+    @Transactional
+      public void delete(Long id, Long deletedBy) {
+        StorePost storePost = findById(id);
+        storePost.delete(deletedBy);
+      }
 }


### PR DESCRIPTION
[BE-50] [BE-52] [BE-53]

#### 🧾 티켓
[[CEO] 소식 작성 API](https://www.notion.so/benkang/CEO-API-1d783feabad380b0a2eecafa3bb5bc8b?pvs=4)
[[CEO] 소식 수정 API](https://www.notion.so/benkang/CEO-API-1d783feabad3800b8894c268318cbabb?pvs=4)
[[CEO] 소식 삭제 API](https://www.notion.so/benkang/CEO-API-1d783feabad380fab1fcf71f2060816c?pvs=4)

##

#### 🔧 작업 내용
- StorePost 작성, 수정, 삭제 API를 BE-50 브랜치 하나로 통합하여 구현했습니다
- 저번 PR 코드 리뷰 반영하여 `NotificationEventListener` 클래스명 변경하였습니다
- 4/27 팀 회의 내용 반영하여 `UserNotificationService`에 findById 필터 처리 추가하였습니다


[ API ]
`CeoCreateStorePostRequest` - 소식 생성 요청 DTO
`CeoUpdateStorePostRequest` - 소식 수정 요청 DTO
`CeoStorePostService` - CEO 소식 비즈니스 로직 추가
`CeoStorePostController` - 생성/수정/삭제 API 엔드포인트 구현


[ Core ]
`StorePostService` - 소식 등록/수정/삭제 기능 처리
`ErrorCode` - 소식 관련 에러 코드 추가