### PR TITLE
[BE-71] [CEO] StoreNotification 모델링 및 조회 API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/storenotification/CeoStoreNotificationController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/storenotification/CeoStoreNotificationController.java
@@ -1,0 +1,39 @@
+package im.fooding.app.controller.ceo.storenotification;
+
+import im.fooding.app.dto.response.ceo.storenotification.CeoStoreNotificationResponse;
+import im.fooding.app.service.ceo.storenotification.CeoStoreNotificationService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.BasicSearch;
+import im.fooding.core.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ceo/store-notifications")
+@Tag(name = "CeoStoreNotificationController", description = "점주 가게 알림 컨트롤러")
+@Slf4j
+public class CeoStoreNotificationController {
+    private final CeoStoreNotificationService ceoStoreNotificationService;
+
+    @GetMapping
+    @Operation(summary = "점주 가게 알림 전체 조회(전체/카테고리별)")
+    public ApiResult<PageResponse<CeoStoreNotificationResponse>> list(
+            @RequestParam Long storeId,
+            @RequestParam(required = false) String category,
+            @ModelAttribute BasicSearch search
+    ) {
+      Pageable pageable = search.getPageable();
+
+      PageResponse<CeoStoreNotificationResponse> response =
+              (category == null || category.trim().isEmpty())
+                      ? ceoStoreNotificationService.list(storeId, pageable)
+                      : ceoStoreNotificationService.listByCategory(storeId, category, pageable);
+
+      return ApiResult.ok(response);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/storenotification/CeoStoreNotificationResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/storenotification/CeoStoreNotificationResponse.java
@@ -1,0 +1,59 @@
+package im.fooding.app.dto.response.ceo.storenotification;
+
+import im.fooding.core.model.store.StoreNotification;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CeoStoreNotificationResponse {
+    @Schema(description = "가게 알림 id", example = "1")
+    private Long id;
+
+    @Schema(description = "알림 제목", example = "예약")
+    private String title;
+
+    @Schema(description = "알림 내용", example = "홍길동님이 예약하셨습니다.")
+    private String content;
+
+    @Schema(description = "알림 카테고리", example = "예약")
+    private String category;
+
+    @Schema(description = "알림 URL", example = "https://ceo.fooding.com/reservations/1234")
+    private String linkUrl;
+
+    @Schema(description = "등록 일자", example = "2025-05-05 12:00:00")
+    private LocalDateTime createdAt;
+
+    @Builder
+    private CeoStoreNotificationResponse(
+            Long id,
+            String title,
+            String content,
+            String category,
+            String linkUrl,
+            LocalDateTime createdAt
+    ){
+      this.id = id;
+      this.title = title;
+      this.content = content;
+      this.category = category;
+      this.linkUrl = linkUrl;
+      this.createdAt = createdAt;
+    }
+
+    public static CeoStoreNotificationResponse from(StoreNotification storeNotification) {
+      return new CeoStoreNotificationResponse(
+              storeNotification.getId(),
+              storeNotification.getTitle(),
+              storeNotification.getContent(),
+              storeNotification.getCategory(),
+              storeNotification.getLinkUrl(),
+              storeNotification.getCreatedAt()
+      );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/storenotification/CeoStoreNotificationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/storenotification/CeoStoreNotificationService.java
@@ -1,0 +1,37 @@
+package im.fooding.app.service.ceo.storenotification;
+
+import im.fooding.app.dto.response.ceo.storenotification.CeoStoreNotificationResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.store.StoreNotification;
+import im.fooding.core.service.store.StoreNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class CeoStoreNotificationService {
+    private final StoreNotificationService storeNotificationService;
+
+    public PageResponse<CeoStoreNotificationResponse> list(Long storeId, Pageable pageable) {
+      Page<StoreNotification> page = storeNotificationService.list(storeId, pageable);
+      List<CeoStoreNotificationResponse> content = page.map(CeoStoreNotificationResponse::from).getContent();
+
+      return PageResponse.of(content, PageInfo.of(page));
+    }
+
+    public PageResponse<CeoStoreNotificationResponse> listByCategory(Long storeId, String category, Pageable pageable) {
+      Page<StoreNotification> page = storeNotificationService.listByCategory(storeId, category, pageable);
+      List<CeoStoreNotificationResponse> content = page.map(CeoStoreNotificationResponse::from).getContent();
+
+      return PageResponse.of(content, PageInfo.of(page));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StoreNotification.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StoreNotification.java
@@ -1,0 +1,52 @@
+package im.fooding.core.model.store;
+
+import im.fooding.core.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class StoreNotification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Store store;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(nullable = false)
+    private String linkUrl;
+
+    @Builder
+    public StoreNotification(Store store, String title, String content, String category, String linkUrl) {
+      this.store = store;
+      this.title = title;
+      this.content = content;
+      this.category = category;
+      this.linkUrl = linkUrl;
+    }
+
+    public void update(String title, String content, String category, String linkUrl) {
+      this.title = title;
+      this.content = content;
+      this.category = category;
+      this.linkUrl = linkUrl;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/StoreNotificationRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/StoreNotificationRepository.java
@@ -1,0 +1,14 @@
+package im.fooding.core.repository.store;
+
+import im.fooding.core.model.store.StoreNotification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreNotificationRepository extends JpaRepository<StoreNotification, Long> {
+    Page<StoreNotification> findByStoreIdOrderByCreatedAtDesc(Long storeId, Pageable pageable);
+
+    Page<StoreNotification> findByStoreIdAndCategoryOrderByCreatedAtDesc(Long storeId, String category, Pageable pageable);
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreNotificationService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreNotificationService.java
@@ -1,0 +1,26 @@
+package im.fooding.core.service.store;
+
+import im.fooding.core.model.store.StoreNotification;
+import im.fooding.core.repository.store.StoreNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class StoreNotificationService {
+    private final StoreNotificationRepository storeNotificationRepository;
+
+    public Page<StoreNotification> list(Long storeId, Pageable pageable){
+      return storeNotificationRepository.findByStoreIdOrderByCreatedAtDesc(storeId, pageable);
+    }
+
+    public Page<StoreNotification> listByCategory(Long storeId, String category, Pageable pageable) {
+      return storeNotificationRepository.findByStoreIdAndCategoryOrderByCreatedAtDesc(storeId, category, pageable);
+    }
+}


### PR DESCRIPTION
[BE-71]

#### 🧾 티켓
[[CEO] StoreNotification 모델링 및 조회 API](https://www.notion.so/benkang/CEO-StoreNotification-API-1e183feabad380c2bd49fed996a53738?pvs=4)

##

#### 🔧 작업 내용

[ API ]
`CeoStoreNotificationService` - 알림 조회 로직
`CeoStoreNotificationResponse` - 가게 알림 응답 DTO
`CeoStoreNotificationController` - 조회 API 엔드포인트


[ Core ]
`StoreNotification` - 가게 알림 엔티티
`StoreNotificationRepository` - 조회 쿼리 메소드
`StoreNotificationService` - 엔티티 조회 로직