### PR TITLE
[BE-93] 인증 기능 적용 전 Swagger 확인을 위한 인증 코드 주석 처리

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
@@ -41,9 +41,10 @@ public class SecurityConfig {
                 .sessionManagement((sess) -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
                         .requestMatchers((this.getPermitUrls())).permitAll()
-                        .requestMatchers("/user/**").hasAnyRole("USER")
-                        .requestMatchers("/admin/**").hasAnyRole("ADMIN")
-                        .requestMatchers("/ceo/**").hasAnyRole("CEO")
+                        // todo: 인증기능 추가 후 주석 해제
+//                        .requestMatchers("/user/**").hasAnyRole("USER")
+//                        .requestMatchers("/admin/**").hasAnyRole("ADMIN")
+//                        .requestMatchers("/ceo/**").hasAnyRole("CEO")
                         .anyRequest().permitAll());
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();


### PR DESCRIPTION
## 관련 티켓
- [인증 코드 임시 주석 처리](https://www.notion.so/benkang/1e983feabad3807f92d0dd31bf03ade2?pvs=4)

## 주요 변경사항
- 인증 없이 Swagger를 통해 API 확인 가능하도록 인증 관련 코드 주석 처리했습니다.
- todo주석을 남겨놓아 추후에 인증 적용 후 주석 해제할 수 있도록 했습니다.