### PR TITLE
[BE-51] [User] 소식 조회 API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStorePostController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStorePostController.java
@@ -1,0 +1,35 @@
+package im.fooding.app.controller.user.store;
+
+import im.fooding.app.dto.response.user.store.UserStorePostResponse;
+import im.fooding.app.service.user.store.UserStorePostService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/store-posts")
+@Tag(name = "UserStorePostController", description = "유저 가게 소식 컨트롤러")
+@Slf4j
+public class UserStorePostController {
+    private final UserStorePostService userStorePostService;
+
+    @GetMapping
+    @Operation(summary = "유저 가게 소식 전체 조회")
+    public ApiResult<List<UserStorePostResponse>> list(@RequestParam Long storeId) {
+      List<UserStorePostResponse> storePosts = userStorePostService.list(storeId);
+      return ApiResult.ok(storePosts);
+    }
+
+    @GetMapping("/{storePostId}")
+    @Operation(summary = "유저 가게 소식 상세 조회")
+    public ApiResult<UserStorePostResponse> retrieve(@PathVariable Long storePostId) {
+      UserStorePostResponse response = userStorePostService.retrieve(storePostId);
+      return ApiResult.ok(response);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/storepost/StorePostResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/storepost/StorePostResponse.java
@@ -32,7 +32,7 @@ public class StorePostResponse {
 
     @Builder
     private StorePostResponse(
-            Long id,
+            long id,
             String title,
             String content,
             List<String> tags,

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStorePostResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStorePostResponse.java
@@ -1,0 +1,60 @@
+package im.fooding.app.dto.response.user.store;
+
+import im.fooding.core.model.store.StorePost;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class UserStorePostResponse {
+    @Schema(description = "유저 소식 ID", example = "1")
+    private long id;
+
+    @Schema(description = "소식 제목", example = "점심시간 예약 관련 공지")
+    private String title;
+
+    @Schema(description = "소식 내용", example = "점심시간에는 예약 없이 방문 시 대기시간이 길어질 수 있습니다.")
+    private String content;
+
+    @Schema(description = "태그 목록", example = "[\"대표\", \"소식\"]")
+    private List<String> tags;
+
+    @Schema(description = "상단 고정 여부", example = "true")
+    private boolean isFixed;
+
+    @Schema(description = "등록 일자", example = "2025-04-25 12:00:00")
+    private LocalDateTime createdAt;
+
+    @Builder
+    private UserStorePostResponse(
+            long id,
+            String title,
+            String content,
+            List<String> tags,
+            boolean isFixed,
+            LocalDateTime createdAt
+    ) {
+      this.id = id;
+      this.title = title;
+      this.content = content;
+      this.tags = tags;
+      this.isFixed = isFixed;
+      this.createdAt = createdAt;
+    }
+
+    public static UserStorePostResponse from(StorePost storePost) {
+      return new UserStorePostResponse(
+              storePost.getId(),
+              storePost.getTitle(),
+              storePost.getContent(),
+              storePost.getTags(),
+              storePost.isFixed(),
+              storePost.getCreatedAt()
+      );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStorePostService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStorePostService.java
@@ -1,0 +1,31 @@
+package im.fooding.app.service.user.store;
+
+import im.fooding.app.dto.response.user.store.UserStorePostResponse;
+import im.fooding.core.model.store.StorePost;
+import im.fooding.core.service.store.StorePostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class UserStorePostService {
+    private final StorePostService storePostService;
+
+    public List<UserStorePostResponse> list(Long storeId) {
+      return storePostService.list(storeId).stream()
+              .map(UserStorePostResponse::from)
+              .collect(Collectors.toList());
+    }
+
+    public UserStorePostResponse retrieve(Long storePostId) {
+      StorePost storePost = storePostService.findById(storePostId);
+      return UserStorePostResponse.from(storePost);
+    }
+}


### PR DESCRIPTION
[BE-51]

#### 🧾 티켓
[[User] 소식 조회 API](https://www.notion.so/benkang/User-API-1d783feabad380439ad3cbac5de31696?pvs=4)

##

#### 🔧 작업 내용

[CEO] StorePostResponse의 경우 변수 타입 변경이 필요하여 같이 추가해놨습니다!

[ API ]
`UserStorePostResponse` - 유저 가게 소식 응답 DTO
`UserStorePostService` - 유저 소식 조회 기능 구현
`UserStorePostController` -  유저 조회 API 엔드포인트 추가