### PR TITLE
[BE-70] 파일 업로드, 커밋 로직 구현

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/file/FileUploadController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/file/FileUploadController.java
@@ -1,0 +1,29 @@
+package im.fooding.app.controller.file;
+
+import im.fooding.app.dto.request.file.FileUploadRequest;
+import im.fooding.app.dto.response.file.FileResponse;
+import im.fooding.app.service.file.FileUploadService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/files")
+@Tag(name = "FileUploadController", description = "파일 컨트롤러")
+public class FileUploadController {
+    private final FileUploadService fileUploadService;
+
+    @PostMapping
+    @Operation(summary = "파일 업로드", description = "파일을  업로드합니다")
+    public ApiResult<List<FileResponse>> upload(@Valid FileUploadRequest request) {
+        return fileUploadService.upload(request);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/file/FileUploadController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/file/FileUploadController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/files")
+@RequestMapping("/file-upload")
 @Tag(name = "FileUploadController", description = "파일 컨트롤러")
 public class FileUploadController {
     private final FileUploadService fileUploadService;
@@ -24,6 +24,6 @@ public class FileUploadController {
     @PostMapping
     @Operation(summary = "파일 업로드", description = "파일을  업로드합니다")
     public ApiResult<List<FileResponse>> upload(@Valid FileUploadRequest request) {
-        return fileUploadService.upload(request);
+        return ApiResult.ok(fileUploadService.upload(request));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/users/UserController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/users/UserController.java
@@ -1,7 +1,6 @@
 package im.fooding.app.controller.user.users;
 
 import im.fooding.app.dto.response.admin.manager.AdminManagerResponse;
-import im.fooding.app.service.admin.manager.AdminManagerApplicationService;
 import im.fooding.app.service.user.user.UserApplicationService;
 import im.fooding.core.common.ApiResult;
 import im.fooding.core.global.UserInfo;

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/file/FileUploadRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/file/FileUploadRequest.java
@@ -1,0 +1,15 @@
+package im.fooding.app.dto.request.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@NoArgsConstructor
+public class FileUploadRequest {
+    @NotNull(message = "파일을 전송해주세요.")
+    @Schema(description = "파일", example = "첨부파일")
+    private MultipartFile[] files;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/file/FileUploadRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/file/FileUploadRequest.java
@@ -4,12 +4,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class FileUploadRequest {
-    @NotNull(message = "파일을 전송해주세요.")
+    @NotNull
     @Schema(description = "파일", example = "첨부파일")
     private MultipartFile[] files;
+
+    public FileUploadRequest(MultipartFile[] files) {
+        this.files = files;
+    }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/file/FileResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/file/FileResponse.java
@@ -1,28 +1,30 @@
 package im.fooding.app.dto.response.file;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class FileResponse {
-    @Schema(description = "id", example = "uuid")
-    private Long id;
+    @Schema(description = "id", example = "819f4bca-2739-46ca-9156-332c86eda619")
+    private String id;
 
-    @Schema(description = "파일명", example = "11.png")
+    @Schema(description = "파일명", example = "819f4bca-2739-46ca-9156-332c86eda619")
     private String name;
 
-    @Schema(description = "url", example = "https://...")
+    @Schema(description = "url", example = "https://d27gz6v6wvae1d.cloudfront.net/fooding/gigs/...")
     private String url;
 
-    @Schema(description = "파일 사이즈(byte)", example = "7012")
-    private Long fileSize;
+    @Schema(description = "크기", example = "68813")
+    private long size;
 
-    public FileResponse(Long id, String name, String url, Long fileSize) {
+    @Builder
+    public FileResponse(String id, String name, String url, long size) {
         this.id = id;
         this.name = name;
         this.url = url;
-        this.fileSize = fileSize;
+        this.size = size;
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/file/FileResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/file/FileResponse.java
@@ -1,0 +1,28 @@
+package im.fooding.app.dto.response.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FileResponse {
+    @Schema(description = "id", example = "uuid")
+    private Long id;
+
+    @Schema(description = "파일명", example = "11.png")
+    private String name;
+
+    @Schema(description = "url", example = "https://...")
+    private String url;
+
+    @Schema(description = "파일 사이즈(byte)", example = "7012")
+    private Long fileSize;
+
+    public FileResponse(Long id, String name, String url, Long fileSize) {
+        this.id = id;
+        this.name = name;
+        this.url = url;
+        this.fileSize = fileSize;
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/file/FileResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/file/FileResponse.java
@@ -11,7 +11,7 @@ public class FileResponse {
     @Schema(description = "id", example = "819f4bca-2739-46ca-9156-332c86eda619")
     private String id;
 
-    @Schema(description = "파일명", example = "819f4bca-2739-46ca-9156-332c86eda619")
+    @Schema(description = "파일명", example = "test.png")
     private String name;
 
     @Schema(description = "url", example = "https://d27gz6v6wvae1d.cloudfront.net/fooding/gigs/...")

--- a/fooding-api/src/main/java/im/fooding/app/service/file/FileUploadService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/file/FileUploadService.java
@@ -1,0 +1,22 @@
+package im.fooding.app.service.file;
+
+import im.fooding.app.dto.request.file.FileUploadRequest;
+import im.fooding.app.dto.response.file.FileResponse;
+import im.fooding.core.service.file.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileUploadService {
+    private final FileService fileService;
+
+    public List<FileResponse> upload(FileUploadRequest request) {
+//        fileService.create();
+        return null;
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/file/FileUploadService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/file/FileUploadService.java
@@ -7,6 +7,7 @@ import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.global.feign.client.StorageClient;
 import im.fooding.core.global.feign.dto.storage.StorageInfo;
 import im.fooding.core.global.feign.dto.storage.StorageResponse;
+import im.fooding.core.model.file.File;
 import im.fooding.core.service.file.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,18 +54,17 @@ public class FileUploadService {
     }
 
     @Transactional
-    public void commit(List<String> ids) {
-        if (ids != null && !ids.isEmpty()) {
-            ids.forEach(id -> {
-                if (StringUtils.hasText(id)) {
-                    fileService.commit(id);
-                    try {
-                        storageClient.commit(storageInfo.getCommitUri(id), storageInfo.getAccessToken());
-                    } catch (Exception e) {
-                        throw new ApiException(ErrorCode.FILE_UPLOAD_FAILED, e.getMessage());
-                    }
-                }
-            });
+    public File commit(String id) {
+        if (StringUtils.hasText(id)) {
+            try {
+                File file = fileService.commit(id);
+                storageClient.commit(storageInfo.getCommitUri(id), storageInfo.getAccessToken());
+                return file;
+            } catch (Exception e) {
+                throw new ApiException(ErrorCode.FILE_UPLOAD_FAILED, e.getMessage());
+            }
+        } else {
+            return null;
         }
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/file/FileUploadService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/file/FileUploadService.java
@@ -2,21 +2,69 @@ package im.fooding.app.service.file;
 
 import im.fooding.app.dto.request.file.FileUploadRequest;
 import im.fooding.app.dto.response.file.FileResponse;
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.global.feign.client.StorageClient;
+import im.fooding.core.global.feign.dto.storage.StorageInfo;
+import im.fooding.core.global.feign.dto.storage.StorageResponse;
 import im.fooding.core.service.file.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static im.fooding.core.global.util.FileValidator.validateFile;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class FileUploadService {
     private final FileService fileService;
+    private final StorageClient storageClient;
+    private final StorageInfo storageInfo;
 
+    @Transactional
     public List<FileResponse> upload(FileUploadRequest request) {
-//        fileService.create();
-        return null;
+        List<FileResponse> files = new ArrayList<>();
+        for (MultipartFile multipartFile : request.getFiles()) {
+            validateFile(multipartFile);
+            try {
+                StorageResponse storageResponse = storageClient.upload(storageInfo.getUploadUri(), storageInfo.getAccessToken(), multipartFile);
+                if (storageResponse != null) {
+                    fileService.create(storageResponse.getId(), storageResponse.getFileName(), storageResponse.getPublicUrl(), storageResponse.getFileSize());
+                    FileResponse fileResponse = FileResponse.builder()
+                            .id(storageResponse.getId())
+                            .url(storageResponse.getPublicUrl())
+                            .name(storageResponse.getFileName())
+                            .size(storageResponse.getFileSize())
+                            .build();
+                    files.add(fileResponse);
+                }
+            } catch (Exception e) {
+                throw new ApiException(ErrorCode.FILE_UPLOAD_FAILED, e.getMessage());
+            }
+        }
+        return files;
+    }
+
+    @Transactional
+    public void commit(List<String> ids) {
+        if (ids != null && !ids.isEmpty()) {
+            ids.forEach(id -> {
+                if (StringUtils.hasText(id)) {
+                    fileService.commit(id);
+                    try {
+                        storageClient.commit(storageInfo.getCommitUri(id), storageInfo.getAccessToken());
+                    } catch (Exception e) {
+                        throw new ApiException(ErrorCode.FILE_UPLOAD_FAILED, e.getMessage());
+                    }
+                }
+            });
+        }
     }
 }

--- a/fooding-api/src/main/resources/application-local.yml
+++ b/fooding-api/src/main/resources/application-local.yml
@@ -57,7 +57,7 @@ logging:
 
 webhook:
   slack:
-    url: ${WEBHOOK_SLACK_URL}
+    url: ${WEBHOOK_SLACK_URL:}
 
 message:
   sender: 02-1234-5678
@@ -92,9 +92,9 @@ auth:
     redirect-uri: https://localhost.com:8080/user/auth/apple/token
 
 storage:
-  base-uri: ${STORAGE_BASE_URI}
-  bucket-id: ${STORAGE_BUCKET_ID}
-  access-token: ${STORAGE_ACCESS_TOKEN}
+  base-uri: ${STORAGE_BASE_URI:}
+  bucket-id: ${STORAGE_BUCKET_ID:}
+  access-token: ${STORAGE_ACCESS_TOKEN:}
 
 #server:
 #  port: 8080

--- a/fooding-api/src/main/resources/application-local.yml
+++ b/fooding-api/src/main/resources/application-local.yml
@@ -91,6 +91,11 @@ auth:
     token-uri: https://appleid.apple.com/auth/token
     redirect-uri: https://localhost.com:8080/user/auth/apple/token
 
+storage:
+  base-uri: ${STORAGE_BASE_URI}
+  bucket-id: ${STORAGE_BUCKET_ID}
+  access-token: ${STORAGE_ACCESS_TOKEN}
+
 #server:
 #  port: 8080
 #  ssl:

--- a/fooding-api/src/main/resources/application-prod.yml
+++ b/fooding-api/src/main/resources/application-prod.yml
@@ -89,3 +89,8 @@ auth:
     private-key: ${APPLE_PRIVATE_KEY:MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgrHlqh7uGlOTNbxyBSeyyZ4JyLKNMDboPO+K4he/6URKgCgYIKoZIzj0DAQehRANCAASN1R+nHzVoAbh7kRGG4GBdlOAqZTWsvC4AaWjQl2osHTB7Vu2ctjTvKJTD6Col9dCt4eFTPSQyMX+7ezJyucy2}
     token-uri: ${APPLE_TOKEN_URI:https://appleid.apple.com/auth/token}
     redirect-uri: ${APPLE_REDIRECT_URI:https://api.fooding.im/api/auth/social/callback}
+
+storage:
+  base-uri: ${STORAGE_BASE_URI}
+  bucket-id: ${STORAGE_BUCKET_ID}
+  access-token: ${STORAGE_ACCESS_TOKEN}

--- a/fooding-api/src/main/resources/application-prod.yml
+++ b/fooding-api/src/main/resources/application-prod.yml
@@ -56,7 +56,7 @@ logging:
 
 webhook:
   slack:
-    url: ${WEBHOOK_SLACK_URL}
+    url: ${WEBHOOK_SLACK_URL:}
 
 message:
   sender: ${MESSAGE_SENDER:02-1234-5678}
@@ -91,6 +91,6 @@ auth:
     redirect-uri: ${APPLE_REDIRECT_URI:https://api.fooding.im/api/auth/social/callback}
 
 storage:
-  base-uri: ${STORAGE_BASE_URI}
-  bucket-id: ${STORAGE_BUCKET_ID}
-  access-token: ${STORAGE_ACCESS_TOKEN}
+  base-uri: ${STORAGE_BASE_URI:}
+  bucket-id: ${STORAGE_BUCKET_ID:}
+  access-token: ${STORAGE_ACCESS_TOKEN:}

--- a/fooding-api/src/main/resources/application-stage.yml
+++ b/fooding-api/src/main/resources/application-stage.yml
@@ -56,7 +56,7 @@ logging:
 
 webhook:
   slack:
-    url: ${WEBHOOK_SLACK_URL}
+    url: ${WEBHOOK_SLACK_URL:}
 
 message:
   sender: ${MESSAGE_SENDER:02-1234-5678}
@@ -91,6 +91,6 @@ auth:
     redirect-uri: ${APPLE_REDIRECT_URI:https://localhost.com/api/auth/social/callback}
 
 storage:
-  base-uri: ${STORAGE_BASE_URI}
-  bucket-id: ${STORAGE_BUCKET_ID}
-  access-token: ${STORAGE_ACCESS_TOKEN}
+  base-uri: ${STORAGE_BASE_URI:}
+  bucket-id: ${STORAGE_BUCKET_ID:}
+  access-token: ${STORAGE_ACCESS_TOKEN:}

--- a/fooding-api/src/main/resources/application-stage.yml
+++ b/fooding-api/src/main/resources/application-stage.yml
@@ -89,3 +89,8 @@ auth:
     private-key: ${APPLE_PRIVATE_KEY:MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgrHlqh7uGlOTNbxyBSeyyZ4JyLKNMDboPO+K4he/6URKgCgYIKoZIzj0DAQehRANCAASN1R+nHzVoAbh7kRGG4GBdlOAqZTWsvC4AaWjQl2osHTB7Vu2ctjTvKJTD6Col9dCt4eFTPSQyMX+7ezJyucy2}
     token-uri: ${APPLE_TOKEN_URI:https://appleid.apple.com/auth/token}
     redirect-uri: ${APPLE_REDIRECT_URI:https://localhost.com/api/auth/social/callback}
+
+storage:
+  base-uri: ${STORAGE_BASE_URI}
+  bucket-id: ${STORAGE_BUCKET_ID}
+  access-token: ${STORAGE_ACCESS_TOKEN}

--- a/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
 //                        .requestMatchers("/user/**").hasAnyRole("USER")
 //                        .requestMatchers("/admin/**").hasAnyRole("ADMIN")
 //                        .requestMatchers("/ceo/**").hasAnyRole("CEO")
+//                        .requestMatchers(HttpMethod.POST, "/file-upload").hasAnyRole("USER", "ADMIN", "CEO")
                         .anyRequest().permitAll());
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     DATABASE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "0012", "데이터베이스 에러 입니다."),
     FEIGN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "0013", "토큰이 만료되었습니다."),
     OAUTH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "0014", "소셜로그인에 실패하셨습니다."),
+    FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "0015", "파일의 정보가 없습니다."),
+    FILE_SIZE_INVALID(HttpStatus.BAD_REQUEST, "0016", "파일 크기가 허용된 최대 크기를 초과했습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "0017", "파일 업로드에 실패했습니다."),
 
     // 회원
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "1000", "가입된 정보가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/global/feign/client/StorageClient.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/feign/client/StorageClient.java
@@ -1,0 +1,23 @@
+package im.fooding.core.global.feign.client;
+
+import im.fooding.core.global.feign.dto.storage.StorageResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+
+@FeignClient(name = "storageClient")
+public interface StorageClient {
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    StorageResponse upload(URI baseUrl,
+                           @RequestHeader("x-bucket-token") String authorization,
+                           @RequestPart("file") MultipartFile file);
+
+    @PostMapping
+    void commit(URI baseUrl,
+                @RequestHeader("x-bucket-token") String authorization);
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/feign/dto/storage/StorageInfo.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/feign/dto/storage/StorageInfo.java
@@ -1,0 +1,41 @@
+package im.fooding.core.global.feign.dto.storage;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Component
+@Getter
+public class StorageInfo {
+    private final String baseUri;
+    private final String bucketId;
+    private final String accessToken;
+
+    public StorageInfo(@Value("${storage.base-uri:null}") String baseUri,
+                       @Value("${storage.bucket-id:null}") String bucketId,
+                       @Value("${storage.access-token:null}") String accessToken) {
+        this.baseUri = baseUri;
+        this.bucketId = bucketId;
+        this.accessToken = accessToken;
+    }
+
+    public URI getUploadUri() {
+        return UriComponentsBuilder
+                .fromHttpUrl(baseUri)
+                .path("/upload/public")
+                .queryParam("bucketId", bucketId)
+                .build()
+                .toUri();
+    }
+
+    public URI getCommitUri(String id) {
+        return UriComponentsBuilder
+                .fromHttpUrl(baseUri)
+                .pathSegment(id, "commit")
+                .build()
+                .toUri();
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/feign/dto/storage/StorageResponse.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/feign/dto/storage/StorageResponse.java
@@ -1,0 +1,30 @@
+package im.fooding.core.global.feign.dto.storage;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StorageResponse {
+    private String id;
+    private String fileName;
+    private String fileKey;
+    private long fileSize;
+    private String mimeType;
+    private boolean isPublic;
+    private String bucketId;
+    private String url;
+    private String publicUrl;
+
+    public StorageResponse(String id, String fileName, String fileKey, long fileSize, String mimeType, boolean isPublic, String bucketId, String url, String publicUrl) {
+        this.id = id;
+        this.fileName = fileName;
+        this.fileKey = fileKey;
+        this.fileSize = fileSize;
+        this.mimeType = mimeType;
+        this.isPublic = isPublic;
+        this.bucketId = bucketId;
+        this.url = url;
+        this.publicUrl = publicUrl;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/util/FileValidator.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/util/FileValidator.java
@@ -1,0 +1,39 @@
+package im.fooding.core.global.util;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FileValidator {
+    private static final List<String> IMAGE_CONTENT_TYPES = Arrays.asList(
+            "image/jpeg", "image/png", "image/gif", "image/webp"
+    );
+
+    private static final long MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    public static void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ApiException(ErrorCode.FILE_NOT_FOUND);
+        }
+
+        String contentType = file.getContentType();
+
+        if (isImage(contentType)) {
+            if (file.getSize() > MAX_IMAGE_SIZE) {
+                throw new ApiException(ErrorCode.FILE_SIZE_INVALID);
+            }
+        } else {
+            if (file.getSize() > MAX_FILE_SIZE) {
+                throw new ApiException(ErrorCode.FILE_SIZE_INVALID);
+            }
+        }
+    }
+
+    private static boolean isImage(String contentType) {
+        return contentType != null && IMAGE_CONTENT_TYPES.contains(contentType.toLowerCase());
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/file/File.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/file/File.java
@@ -1,0 +1,36 @@
+package im.fooding.core.model.file;
+
+import im.fooding.core.model.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class File extends BaseEntity {
+    @Id
+    private String id;
+
+    private String originalName;
+
+    private String storedName;
+
+    private String url;
+
+    private Long size;
+
+    @Builder
+    public File(String id, String originalName, String storedName, String url, Long size) {
+        this.id = id;
+        this.originalName = originalName;
+        this.storedName = storedName;
+        this.url = url;
+        this.size = size;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/file/File.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/file/File.java
@@ -17,20 +17,23 @@ public class File extends BaseEntity {
     @Id
     private String id;
 
-    private String originalName;
-
-    private String storedName;
+    private String name;
 
     private String url;
 
     private Long size;
 
+    private boolean committed;
+
     @Builder
-    public File(String id, String originalName, String storedName, String url, Long size) {
+    public File(String id, String name, String url, Long size) {
         this.id = id;
-        this.originalName = originalName;
-        this.storedName = storedName;
+        this.name = name;
         this.url = url;
         this.size = size;
+    }
+
+    public void commit() {
+        this.committed = true;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/file/FileRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/file/FileRepository.java
@@ -3,5 +3,5 @@ package im.fooding.core.repository.file;
 import im.fooding.core.model.file.File;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FileRepository extends JpaRepository<File, Long> {
+public interface FileRepository extends JpaRepository<File, String> {
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/file/FileRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/file/FileRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.file;
+
+import im.fooding.core.model.file.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/file/FileService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/file/FileService.java
@@ -1,5 +1,7 @@
 package im.fooding.core.service.file;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.file.File;
 import im.fooding.core.repository.file.FileRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +14,24 @@ import org.springframework.stereotype.Service;
 public class FileService {
     private final FileRepository repository;
 
-    public void create(String id, String originalName, String storedName, String url, long size) {
+    public void create(String id, String name, String url, long size) {
         File file = File.builder()
                 .id(id)
-                .originalName(originalName)
-                .storedName(storedName)
+                .name(name)
                 .url(url)
                 .size(size)
                 .build();
         repository.save(file);
+    }
+
+    public void commit(String id) {
+        File file = findById(id);
+        file.commit();
+    }
+
+    public File findById(String id) {
+        return repository.findById(id)
+                .filter(it -> !it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.FILE_NOT_FOUND));
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/file/FileService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/file/FileService.java
@@ -1,0 +1,25 @@
+package im.fooding.core.service.file;
+
+import im.fooding.core.model.file.File;
+import im.fooding.core.repository.file.FileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileService {
+    private final FileRepository repository;
+
+    public void create(String id, String originalName, String storedName, String url, long size) {
+        File file = File.builder()
+                .id(id)
+                .originalName(originalName)
+                .storedName(storedName)
+                .url(url)
+                .size(size)
+                .build();
+        repository.save(file);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/file/FileService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/file/FileService.java
@@ -24,9 +24,10 @@ public class FileService {
         repository.save(file);
     }
 
-    public void commit(String id) {
+    public File commit(String id) {
         File file = findById(id);
         file.commit();
+        return file;
     }
 
     public File findById(String id) {


### PR DESCRIPTION
## 관련 티켓
- [File Upload API 구현](https://www.notion.so/benkang/USER-File-Upload-API-1e083feabad380fda40fc6ab6ae2c650?pvs=4)

## 설명
- /file-upload 로 업로드 후 File 도메인에 저장 후 id 받는다.
- 받은 id로 이미지 저장할 때 fileUploadService.commit(String id) 해서 커밋한다.