### PR TITLE
BE-136: 유저 알림 전부 읽음 처리로 변경

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/notification/UserNotificationController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/notification/UserNotificationController.java
@@ -52,10 +52,9 @@ public class UserNotificationController {
   @PostMapping("/read")
   @Operation(summary = "유저 알림 읽음 상태 변경")
   public ApiResult<Void> markAsRead(
-      @AuthenticationPrincipal UserInfo userInfo,
-      @RequestBody List<Long> notificationIds) {
+      @AuthenticationPrincipal UserInfo userInfo) {
     Long userId = userInfo.getId();
-    userNotificationApplicationService.markAsRead(userId, notificationIds);
+    userNotificationApplicationService.markAsRead(userId);
     return ApiResult.ok();
   }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -69,10 +69,8 @@ public class UserNotificationApplicationService {
     }
 
     @Transactional
-    public void markAsRead(Long userId, List<Long> notificationIds) {
-        List<UserNotification> notifications = notificationIds.stream()
-                .map(id -> userNotificationService.getNotification(userId, id))
-                .toList();
+    public void markAsRead(Long userId) {
+        List<UserNotification> notifications = userNotificationService.getUnreadUserNotifications(userId);
         notifications.forEach(UserNotification::read);
     }
 

--- a/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/config/SecurityConfig.java
@@ -73,7 +73,12 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(
                 List.of(
+                        // NOTE: 로컬 개발 허용(정규식?)
                         "http://localhost:3000",
+                        "http://localhost:3001",
+                        "http://localhost:3002",
+                        "http://localhost:3003",
+                        // NOTE: 서비스 허용
                         "https://fooding.im",
                         "https://stage.fooding.im",
                         "https://back-office-stage.fooding.im",

--- a/fooding-core/src/main/java/im/fooding/core/repository/notification/UserNotificationRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/notification/UserNotificationRepository.java
@@ -16,4 +16,8 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
     Optional<UserNotification> findByIdAndUserId(Long id, Long userId);
 
     Page<UserNotification> findAllByUserIdOrderBySentAtDesc(Long userId, Pageable pageable);
+
+    List<UserNotification> findAllByUserIdAndIsReadFalseOrderBySentAtDesc(Long userId);
+
+    Page<UserNotification> findAllByUserIdAndIsReadFalseOrderBySentAtDesc(Long userId, Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/notification/UserNotificationService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/notification/UserNotificationService.java
@@ -32,6 +32,10 @@ public class UserNotificationService {
     return userNotificationRepository.findAllByUserIdOrderBySentAtDesc(userId, pageable);
   }
 
+  public List<UserNotification> getUnreadUserNotifications(Long userId) {
+    return userNotificationRepository.findAllByUserIdAndIsReadFalseOrderBySentAtDesc(userId);
+  }
+
   public UserNotification getNotification(Long userId, Long notificationId) {
     UserNotification notification = userNotificationRepository.findById(notificationId)
         .filter(it -> !it.isDeleted())


### PR DESCRIPTION
ids 받지 않고, API 호출만해도 안 읽은 알람들은 API 호출하여 일괄 읽음 처리하도록 수정