### PR TITLE
[BE-169] 웨이팅 현황 조회 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/app/waiting/AppWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/app/waiting/AppWaitingController.java
@@ -2,6 +2,7 @@ package im.fooding.app.controller.app.waiting;
 
 import im.fooding.app.dto.request.app.waiting.AppWaitingListRequest;
 import im.fooding.app.dto.request.app.waiting.AppWaitingRegisterRequest;
+import im.fooding.app.dto.response.app.waiting.AppWaitingOverviewResponse;
 import im.fooding.app.dto.response.app.waiting.AppWaitingRegisterResponse;
 import im.fooding.app.dto.response.app.waiting.AppWaitingLogResponse;
 import im.fooding.app.service.app.waiting.AppWaitingApplicationService;
@@ -69,5 +70,14 @@ public class AppWaitingController {
             @RequestBody @Valid AppWaitingRegisterRequest request
     ) {
         return ApiResult.ok(appWaitingApplicationService.register(id, request));
+    }
+
+    @GetMapping("/{id}/overview")
+    @Operation(summary = "웨이팅 현황 조회")
+    ApiResult<AppWaitingOverviewResponse> overview(
+            @Parameter(description = "웨이팅 id", example = "1")
+            @PathVariable long id
+    ) {
+        return ApiResult.ok(appWaitingApplicationService.overview(id));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/app/waiting/AppWaitingOverviewResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/app/waiting/AppWaitingOverviewResponse.java
@@ -1,0 +1,14 @@
+package im.fooding.app.dto.response.app.waiting;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+@Value
+public class AppWaitingOverviewResponse {
+
+    @Schema(description = "현재 웨이팅 수")
+    int waitingCount;
+
+    @Schema(description = "예상 시간(분)")
+    int estimatedWaitingTimeMinutes;
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/app/waiting/AppWaitingApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/app/waiting/AppWaitingApplicationService.java
@@ -2,6 +2,7 @@ package im.fooding.app.service.app.waiting;
 
 import im.fooding.app.dto.request.app.waiting.AppWaitingListRequest;
 import im.fooding.app.dto.request.app.waiting.AppWaitingRegisterRequest;
+import im.fooding.app.dto.response.app.waiting.AppWaitingOverviewResponse;
 import im.fooding.app.dto.response.app.waiting.AppWaitingRegisterResponse;
 import im.fooding.app.service.user.notification.UserNotificationApplicationService;
 import im.fooding.app.dto.response.app.waiting.AppWaitingLogResponse;
@@ -13,10 +14,12 @@ import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.StoreWaitingChannel;
 import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingLog;
+import im.fooding.core.model.waiting.WaitingSetting;
 import im.fooding.core.model.waiting.WaitingUser;
 import im.fooding.core.service.waiting.StoreWaitingService;
 import im.fooding.core.service.waiting.WaitingLogService;
 import im.fooding.core.service.waiting.WaitingService;
+import im.fooding.core.service.waiting.WaitingSettingService;
 import im.fooding.core.service.waiting.WaitingUserService;
 import im.fooding.app.dto.response.app.waiting.AppStoreWaitingResponse;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +44,7 @@ public class AppWaitingApplicationService {
     private final StoreWaitingService storeWaitingService;
     private final WaitingLogService waitingLogService;
     private final UserNotificationApplicationService userNotificationApplicationService;
+    private final WaitingSettingService waitingSettingService;
 
     public AppStoreWaitingResponse details(long id) {
         return AppStoreWaitingResponse.from(storeWaitingService.get(id));
@@ -130,5 +134,16 @@ public class AppWaitingApplicationService {
                 .toList();
 
         return PageResponse.of(list, PageInfo.of(logs));
+    }
+
+    public AppWaitingOverviewResponse overview(long id) {
+        Waiting waiting = waitingService.get(id);
+        Store store = waiting.getStore();
+        WaitingSetting waitingSetting = waitingSettingService.getActiveSetting(store);
+
+        int waitingCount = (int) storeWaitingService.getWaitingCount(store);
+        int estimatedWaitingTimeMinutes = waitingSetting.getEstimatedWaitingTimeMinutes() * waitingCount;
+
+        return new AppWaitingOverviewResponse(waitingCount, estimatedWaitingTimeMinutes);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/StoreWaitingRepository.java
@@ -15,4 +15,6 @@ public interface StoreWaitingRepository extends JpaRepository<StoreWaiting, Long
     boolean existsByStoreAndStatusAndDeletedFalse(Store store, StoreWaitingStatus status);
 
     Page<StoreWaiting> findAllByDeletedFalse(Pageable pageable);
+
+    long countByStoreAndStatusAndDeletedFalse(Store store, StoreWaitingStatus status);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -143,6 +143,10 @@ public class StoreWaitingService {
         return storeWaitingRepository.existsByStoreAndStatusAndDeletedFalse(store, status);
     }
 
+    public long getWaitingCount(Store store) {
+        return storeWaitingRepository.countByStoreAndStatusAndDeletedFalse(store, StoreWaitingStatus.WAITING);
+    }
+
     // TODO: 추후에 redis 로 개선
     private int generateCallNumber() {
         return (int) storeWaitingRepository.countCreatedOnAndDeletedFalse(LocalDate.now()) + 1;


### PR DESCRIPTION
## 관련 티켓
- [[APP] 웨이팅 현황 API 추가](https://www.notion.so/benkang/APP-API-20583feabad3808fa175fa896c89926e?source=copy_link)

## 주요 변경 사항
- 웨이팅 현황(웨이팅 수, 웨이팅 예상시간)을 반환하는 API 따로 필요함에 따라 추가했습니다!
