### PR TITLE
[BE-171] 웨이팅 등록시 호출번호, 현재 웨이팅, 예상시간, 최근입장 시간 반환하도록 변경

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/dto/response/app/waiting/AppWaitingRegisterResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/app/waiting/AppWaitingRegisterResponse.java
@@ -4,6 +4,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AppWaitingRegisterResponse(
         @Schema(description = "호출 번호", example = "1")
-        long callNumber
+        long callNumber,
+
+        @Schema(description = "현재 웨이팅", example = "10")
+        long waitingTurn,
+
+        @Schema(description = "예상 시간(분)", example = "100")
+        long expectedTimeMinute,
+
+        @Schema(description = "최근 입장(분)", example = "5")
+        long recentEntryTimeMinute
 ) {
 }


### PR DESCRIPTION
## 관련 티켓
- [[APP] 웨이팅 정보 반환 API 추가](https://www.notion.so/benkang/APP-API-20583feabad380d4b357c7b5f5c8c78b?source=copy_link)

## 관련 이슈
- #91

## 변경사항
- #91에서 git 관리 문제가 있어 다시 열었습니다!
- 최근 입장 시간은 5로 하드코딩 해놨습니다!