### PR TITLE
[BE-191] [USER] 지금 바로 입장할 수 있는 식당 목록 조회 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStoreController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStoreController.java
@@ -1,5 +1,6 @@
 package im.fooding.app.controller.user.store;
 
+import im.fooding.app.dto.request.user.store.UserImmediateEntryStoreRequest;
 import im.fooding.app.dto.request.user.store.UserSearchStoreRequest;
 import im.fooding.app.dto.response.user.store.UserStoreListResponse;
 import im.fooding.app.dto.response.user.store.UserStoreResponse;
@@ -34,5 +35,13 @@ public class UserStoreController {
     @Operation(summary = "가게 단건조회")
     public ApiResult<UserStoreResponse> retrieve(@PathVariable Long id) {
         return ApiResult.ok(service.retrieve(id));
+    }
+
+    @GetMapping("/immediate-entry")
+    @Operation(summary = "바로 입장 가능한 식당 목록 조회")
+    public ApiResult<PageResponse<UserStoreListResponse>> retrieveImmediateEntry(
+            @Valid UserImmediateEntryStoreRequest request
+    ) {
+        return ApiResult.ok(service.retrieveImmediateEntry(request));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/store/UserImmediateEntryStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/store/UserImmediateEntryStoreRequest.java
@@ -1,0 +1,6 @@
+package im.fooding.app.dto.request.user.store;
+
+import im.fooding.core.common.BasicSearch;
+
+public class UserImmediateEntryStoreRequest extends BasicSearch {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingRepository.java
@@ -2,6 +2,7 @@ package im.fooding.core.repository.waiting;
 
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.Waiting;
+import im.fooding.core.model.waiting.WaitingStatus;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,8 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     boolean existsByStore(Store store);
 
     Page<Waiting> findAllByDeletedFalse(Pageable pageable);
+
+    Page<Waiting> findAllByStatusAndDeletedFalse(WaitingStatus status, Pageable pageable);
 
     Optional<Waiting> findByStore(Store store);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingService.java
@@ -68,6 +68,10 @@ public class WaitingService {
         return waiting.getStatus() == WaitingStatus.WAITING_OPEN;
     }
 
+    public Page<Waiting> list(WaitingStatus status, Pageable pageable) {
+        return waitingRepository.findAllByStatusAndDeletedFalse(status, pageable);
+    }
+
     private void validateUniqueStore(Store store) {
         if (waitingRepository.existsByStore(store)) {
             throw new ApiException(ErrorCode.DUPLICATED_STORE_BY_WAITING);


### PR DESCRIPTION
## 이슈 티켓
- [[USER] 지금 바로 입장할 수 있는 식당 목록 조회 API 추가](https://www.notion.so/benkang/USER-21883feabad380e49be7c53f697bcaff?source=copy_link)

## 변경 사항
- [BE-191] [USER] 지금 바로 입장할 수 있는 식당 목록 조회 API 추가