### PR TITLE
[BE-194] 활성화 가게 세팅 가게별로 검증하도록 변경

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingSettingRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/waiting/WaitingSettingRepository.java
@@ -1,5 +1,6 @@
 package im.fooding.core.repository.waiting;
 
+import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingSetting;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WaitingSettingRepository extends JpaRepository<WaitingSetting, Long>, QWaitingSettingRepository {
 
-    boolean existsByIsActiveTrueAndDeletedFalse();
+    boolean existsByWaitingAndIsActiveTrueAndDeletedFalse(Waiting waiting);
 
     Page<WaitingSetting> findAllByDeletedFalse(Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingSettingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/WaitingSettingService.java
@@ -5,6 +5,7 @@ import im.fooding.core.dto.request.waiting.WaitingSettingUpdateRequest;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingSetting;
 import im.fooding.core.repository.waiting.WaitingSettingRepository;
 import java.util.Optional;
@@ -26,7 +27,7 @@ public class WaitingSettingService {
     @Transactional
     public void create(WaitingSettingCreateRequest request) {
         if (request.isActive()) {
-            validateAlreadyActive();
+            validateAlreadyActive(request.waiting());
         }
 
         WaitingSetting waitingSetting = WaitingSetting.builder()
@@ -56,7 +57,7 @@ public class WaitingSettingService {
     public void update(WaitingSettingUpdateRequest request) {
         WaitingSetting waitingSetting = get(request.id());
         if (request.isActive() && !waitingSetting.isActive()) {
-            validateAlreadyActive();
+            validateAlreadyActive(request.waiting());
         }
 
         waitingSetting.update(
@@ -92,8 +93,8 @@ public class WaitingSettingService {
                 .filter(it -> !it.isDeleted());
     }
 
-    private void validateAlreadyActive() {
-        if (waitingSettingRepository.existsByIsActiveTrueAndDeletedFalse()) {
+    private void validateAlreadyActive(Waiting waiting) {
+        if (waitingSettingRepository.existsByWaitingAndIsActiveTrueAndDeletedFalse(waiting)) {
             throw new ApiException(ErrorCode.ALREADY_EXIST_ACTIVE_WAITING_SETTING);
         }
     }


### PR DESCRIPTION
## 이슈 티켓
- [활성화된 가게 웨이팅 설정 가게마다 검증하도록 로직 변경](https://www.notion.so/benkang/ADMIN-21a83feabad38055a65ff4b3677c93eb?source=copy_link)

## 주요 변경사항
- 가게의 웨이팅 설정이 활성화 할 때, 각자 가게가 아닌 모든 가게 중에 활성화된 것이 있는지 확인하고 있어서
  각자 가게 기준으로 활성화 검증을 하도록 로직 변경했습니다!