### PR TITLE
[BE-198] Swagger에서 Bearer Token 인증 기능 추가

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/global/config/SwaggerConfig.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/config/SwaggerConfig.java
@@ -1,17 +1,27 @@
 package im.fooding.core.global.config;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@SecurityScheme(
+        name = "Bearer Authentication",
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer"
+)
 @Configuration
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
                 .components(new Components())
                 .info(apiInfo());
     }


### PR DESCRIPTION
**[백로그]**
[BE-198](https://www.notion.so/benkang/Swagger-Barear-Token-21a83feabad3804dbb97c2c4c9902323?source=copy_link)

**[작업 내용]**
- Bearer 토큰을 통해 로그인 후 Token을 받고 Authorize에 추가함으로서 Swagger에서도 토큰 활용 기능을 테스트할 수 있도록 구현