### PR TITLE
가게 소식 조회 첨부된 이미지 필드 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStorePostResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStorePostResponse.java
@@ -1,60 +1,52 @@
 package im.fooding.app.dto.response.user.store;
 
 import im.fooding.core.model.store.StorePost;
+import im.fooding.core.model.store.StorePostImage;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Value;
 
-@Getter
-@NoArgsConstructor
+@Value
+@Builder(access = AccessLevel.PRIVATE)
 public class UserStorePostResponse {
     @Schema(description = "유저 소식 ID", example = "1")
-    private long id;
+    long id;
 
     @Schema(description = "소식 제목", example = "점심시간 예약 관련 공지")
-    private String title;
+    String title;
 
     @Schema(description = "소식 내용", example = "점심시간에는 예약 없이 방문 시 대기시간이 길어질 수 있습니다.")
-    private String content;
+    String content;
+
+    @Schema(description = "이미지 Url")
+    List<String> imageUrls;
 
     @Schema(description = "태그 목록", example = "[\"대표\", \"소식\"]")
-    private List<String> tags;
+    List<String> tags;
 
     @Schema(description = "상단 고정 여부", example = "true")
-    private boolean isFixed;
+    boolean isFixed;
 
     @Schema(description = "등록 일자", example = "2025-04-25 12:00:00")
-    private LocalDateTime createdAt;
+    LocalDateTime createdAt;
 
-    @Builder
-    private UserStorePostResponse(
-            long id,
-            String title,
-            String content,
-            List<String> tags,
-            boolean isFixed,
-            LocalDateTime createdAt
-    ) {
-      this.id = id;
-      this.title = title;
-      this.content = content;
-      this.tags = tags;
-      this.isFixed = isFixed;
-      this.createdAt = createdAt;
-    }
+    public static UserStorePostResponse from(StorePost storePost, List<StorePostImage> storePostImages) {
+        List<String> images = storePostImages.stream()
+                .map(StorePostImage::getImageUrl)
+                .toList();
 
-    public static UserStorePostResponse from(StorePost storePost) {
-      return new UserStorePostResponse(
-              storePost.getId(),
-              storePost.getTitle(),
-              storePost.getContent(),
-              storePost.getTags(),
-              storePost.isFixed(),
-              storePost.getCreatedAt()
-      );
+        return UserStorePostResponse.builder()
+                .id(storePost.getId())
+                .title(storePost.getTitle())
+                .content(storePost.getContent())
+                .imageUrls(images)
+                .tags(storePost.getTags())
+                .isFixed(storePost.isFixed())
+                .createdAt(storePost.getCreatedAt())
+                .build();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStorePostService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStorePostService.java
@@ -2,6 +2,8 @@ package im.fooding.app.service.user.store;
 
 import im.fooding.app.dto.response.user.store.UserStorePostResponse;
 import im.fooding.core.model.store.StorePost;
+import im.fooding.core.model.store.StorePostImage;
+import im.fooding.core.service.store.StorePostImageService;
 import im.fooding.core.service.store.StorePostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,15 +19,21 @@ import java.util.stream.Collectors;
 @Slf4j
 public class UserStorePostService {
     private final StorePostService storePostService;
+    private final StorePostImageService storePostImageService;
 
     public List<UserStorePostResponse> list(Long storeId) {
-      return storePostService.list(storeId).stream()
-              .map(UserStorePostResponse::from)
-              .collect(Collectors.toList());
+
+        return storePostService.list(storeId).stream()
+                .map(storePost -> {
+                    List<StorePostImage> storePostsImages = storePostImageService.list(storePost.getId());
+                    return UserStorePostResponse.from(storePost, storePostsImages);
+                })
+                .collect(Collectors.toList());
     }
 
     public UserStorePostResponse retrieve(Long storePostId) {
       StorePost storePost = storePostService.findById(storePostId);
-      return UserStorePostResponse.from(storePost);
+      List<StorePostImage> storePostsImages = storePostImageService.list(storePostId);
+      return UserStorePostResponse.from(storePost, storePostsImages);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -46,9 +46,12 @@ public enum ErrorCode {
     STORE_INFORMATION_DUPLICATED(HttpStatus.BAD_REQUEST, "2401", "이미 등록된 가게 부가 정보가 있습니다."),
     STORE_OPERATING_HOUR_NOT_FOUND(HttpStatus.BAD_REQUEST, "2500", "등록된 가게 운영시간 및 휴일 정보가 없습니다."),
     STORE_OPERATING_HOUR_DUPLICATED(HttpStatus.BAD_REQUEST, "2501", "이미 등록된 가게 운영시간 및 휴일 정보가 있습니다."),
+    STORE_BOOKMARK_NOT_FOUND(HttpStatus.BAD_REQUEST, "2601", "단골이 아닙니다."),
+    STORE_BOOKMARK_EXIST(HttpStatus.BAD_REQUEST, "2602", "이미 단골입니다."),
+    STORE_POST_IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2001", "등록된 가게 소식 이미지가 없습니다."),
 
     // 리뷰
-    REVIEW_NOT_FOUND( HttpStatus.BAD_REQUEST, "2202", "등록된 리뷰가 없습니다" ),
+    REVIEW_NOT_FOUND( HttpStatus.BAD_REQUEST, "2300", "등록된 리뷰가 없습니다" ),
 
     // 웨이팅
     WAITING_NOT_FOUND(HttpStatus.BAD_REQUEST, "3000", "등록된 웨이팅 정보가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StorePostImage.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StorePostImage.java
@@ -1,0 +1,51 @@
+package im.fooding.core.model.store;
+
+import im.fooding.core.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class StorePostImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "store_post_id",
+            nullable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    @Setter
+    private StorePost storePost;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    public StorePostImage(StorePost storePost, String imageUrl) {
+        this.storePost = storePost;
+        this.imageUrl = imageUrl;
+    }
+
+    public void update(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}
+

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/image/StorePostImageRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/image/StorePostImageRepository.java
@@ -1,0 +1,13 @@
+package im.fooding.core.repository.store.image;
+
+import im.fooding.core.model.store.StorePostImage;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StorePostImageRepository extends JpaRepository<StorePostImage, Long> {
+
+    Optional<StorePostImage> findByStorePostId(long storePostId);
+
+    List<StorePostImage> findAllByStorePostId(long storePostId);
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StorePostImageService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StorePostImageService.java
@@ -1,0 +1,44 @@
+package im.fooding.core.service.store;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.store.StoreImage;
+import im.fooding.core.model.store.StorePost;
+import im.fooding.core.model.store.StorePostImage;
+import im.fooding.core.repository.store.image.StorePostImageRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class StorePostImageService {
+    private final StorePostImageRepository storePostImageRepository;
+
+    public StorePostImage create(StorePost storePost, String imageUrl) {
+        StorePostImage storeImage = new StorePostImage(storePost, imageUrl);
+        return storePostImageRepository.save(storeImage);
+    }
+
+    public Optional<StorePostImage> findById(long id) {
+        return storePostImageRepository.findById(id)
+                .filter(it -> !it.isDeleted());
+    }
+
+    public List<StorePostImage> list(long storePostId) {
+        return storePostImageRepository.findAllByStorePostId(storePostId);
+    }
+
+    public void delete(StoreImage storeImage, long deletedBy) {
+        storeImage.delete(deletedBy);
+    }
+
+    public void update(StorePostImage storePostImage, String imageUrl) {
+        storePostImage.update(imageUrl);
+    }
+}


### PR DESCRIPTION
## 이슈
- [가게 소식 조회 첨부된 이미지 필드 추가](https://www.notion.so/benkang/22783feabad380d7aee9c355bbc082b9?source=copy_link)

## 주요 변경 사항
- 가게 소식 이미지 도메인 추가 ({가게 소식, 가게 소식 이미지}: one To many 관계)
- 가게 소식 조회 첨부된 이미지 필드 추가
- 가게 소식 리스트 조회 이미지 필드 추가