### PR TITLE
[BE-212] Store 에 regionId  저장 및 API 수정

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/app/store/AppStoreController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/app/store/AppStoreController.java
@@ -1,5 +1,6 @@
 package im.fooding.app.controller.app.store;
 
+import im.fooding.app.dto.request.app.store.AppSearchStoreRequest;
 import im.fooding.app.dto.response.app.store.AppStoreResponse;
 import im.fooding.app.service.app.store.AppStoreService;
 import im.fooding.core.common.ApiResult;
@@ -24,8 +25,11 @@ public class AppStoreController {
 
     @GetMapping
     @Operation(summary = "가게 리스트 조회")
-    public ApiResult<List<AppStoreResponse>> list(@AuthenticationPrincipal UserInfo userInfo) {
-        return ApiResult.ok(service.list(userInfo.getId()));
+    public ApiResult<List<AppStoreResponse>> list(
+            @AuthenticationPrincipal UserInfo userInfo,
+            AppSearchStoreRequest search
+    ) {
+        return ApiResult.ok(service.list(userInfo.getId(), search));
     }
 
     @GetMapping("/{id}")

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/stores/CeoStoreController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/stores/CeoStoreController.java
@@ -1,6 +1,7 @@
 package im.fooding.app.controller.ceo.stores;
 
 import im.fooding.app.dto.request.ceo.store.CeoCreateStoreRequest;
+import im.fooding.app.dto.request.ceo.store.CeoSearchStoreRequest;
 import im.fooding.app.dto.request.ceo.store.CeoUpdateStoreRequest;
 import im.fooding.app.dto.response.ceo.store.CeoStoreResponse;
 import im.fooding.app.service.ceo.store.CeoStoreService;
@@ -24,8 +25,11 @@ public class CeoStoreController {
 
     @GetMapping
     @Operation(summary = "가게 전체 조회")
-    public ApiResult<List<CeoStoreResponse>> list(@AuthenticationPrincipal UserInfo userInfo) {
-        return ApiResult.ok(service.list(userInfo.getId()));
+    public ApiResult<List<CeoStoreResponse>> list(
+            @AuthenticationPrincipal UserInfo userInfo,
+            CeoSearchStoreRequest search
+    ) {
+        return ApiResult.ok(service.list(userInfo.getId(), search));
     }
 
     @GetMapping("/{id}")

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
@@ -15,6 +15,10 @@ public class AdminCreateStoreRequest {
     @Schema(description = "가게명", example = "홍가네")
     private String name;
 
+    @NotNull(message = "가게 지역은 필수입니다.")
+    @Schema(description = "가게 지역 ID", example = "KR-11")
+    private String regionId;
+
     @NotBlank(message = "도시는 필수입니다.")
     @Schema(description = "도시", example = "홍대")
     private String city;

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
@@ -11,6 +11,10 @@ public class AdminUpdateStoreRequest {
     @Schema(description = "가게명", example = "홍가네")
     private String name;
 
+    @NotNull(message = "가게 지역은 필수입니다.")
+    @Schema(description = "가게 지역 ID", example = "KR-11")
+    private String regionId;
+
     @NotBlank(message = "도시는 필수입니다.")
     @Schema(description = "도시", example = "홍대")
     private String city;

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/app/store/AppSearchStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/app/store/AppSearchStoreRequest.java
@@ -1,0 +1,16 @@
+package im.fooding.app.dto.request.app.store;
+
+import im.fooding.core.dto.request.store.StoreFilter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+@Value
+public class AppSearchStoreRequest {
+
+    @Schema(description = "지역 ID", example = "KR-11")
+    String regionId;
+
+    public StoreFilter toStoreFilter() {
+        return new StoreFilter(regionId);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoCreateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoCreateStoreRequest.java
@@ -15,6 +15,10 @@ public class CeoCreateStoreRequest {
     @Schema(description = "가게명", example = "홍가네")
     private String name;
 
+    @NotNull(message = "가게 지역은 필수입니다.")
+    @Schema(description = "가게 지역 ID", example = "KR-11")
+    private String regionId;
+
     @NotBlank(message = "도시는 필수입니다.")
     @Schema(description = "도시", example = "홍대")
     private String city;

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoSearchStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoSearchStoreRequest.java
@@ -1,0 +1,16 @@
+package im.fooding.app.dto.request.ceo.store;
+
+import im.fooding.core.dto.request.store.StoreFilter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+@Value
+public class CeoSearchStoreRequest {
+
+    @Schema(description = "지역 ID", example = "KR-11")
+    String regionId;
+
+    public StoreFilter toStoreFilter() {
+        return new StoreFilter(regionId);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoUpdateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoUpdateStoreRequest.java
@@ -13,6 +13,10 @@ public class CeoUpdateStoreRequest {
     @Schema(description = "가게명", example = "홍가네")
     private String name;
 
+    @NotNull(message = "가게 지역은 필수입니다.")
+    @Schema(description = "가게 지역 ID", example = "KR-11")
+    private String regionId;
+
     @NotBlank(message = "도시는 필수입니다.")
     @Schema(description = "도시", example = "홍대")
     private String city;

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/admin/store/AdminStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/admin/store/AdminStoreResponse.java
@@ -17,6 +17,9 @@ public class AdminStoreResponse {
     @Schema(description = "가게명", example = "홍가네", requiredMode = RequiredMode.REQUIRED)
     private final String name;
 
+    @Schema(description = "지역 ID", example = "KR-11", requiredMode = RequiredMode.REQUIRED)
+    private final String regionId;
+
     @Schema(description = "도시", example = "홍대", requiredMode = RequiredMode.REQUIRED)
     private final String city;
 
@@ -66,6 +69,7 @@ public class AdminStoreResponse {
         this.id = store.getId();
         this.ownerId = store.getOwner() != null ? store.getOwner().getId() : null;
         this.name = store.getName();
+        this.regionId = store.getRegion().getId();
         this.city = store.getCity();
         this.address = store.getAddress();
         this.category = store.getCategory();

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreResponse.java
@@ -17,6 +17,9 @@ public class CeoStoreResponse {
     @Schema(description = "가게명", example = "홍가네", requiredMode = RequiredMode.REQUIRED)
     private final String name;
 
+    @Schema(description = "지역 ID", example = "KR-11", requiredMode = RequiredMode.REQUIRED)
+    private final String regionId;
+
     @Schema(description = "도시", example = "홍대", requiredMode = RequiredMode.REQUIRED)
     private final String city;
 
@@ -74,6 +77,7 @@ public class CeoStoreResponse {
     public CeoStoreResponse(Store store) {
         this.id = store.getId();
         this.ownerId = store.getOwner() != null ? store.getOwner().getId() : null;
+        this.regionId = store.getRegion().getId();
         this.name = store.getName();
         this.city = store.getCity();
         this.address = store.getAddress();

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
@@ -6,10 +6,12 @@ import im.fooding.app.dto.request.admin.store.AdminUpdateStoreRequest;
 import im.fooding.app.dto.response.admin.store.AdminStoreResponse;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StorePosition;
 import im.fooding.core.model.user.Role;
 import im.fooding.core.model.user.User;
+import im.fooding.core.service.region.RegionService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
 import im.fooding.core.service.user.UserAuthorityService;
@@ -30,6 +32,7 @@ public class AdminStoreService {
     private final StoreMemberService storeMemberService;
     private final UserService userService;
     private final UserAuthorityService userAuthorityService;
+    private final RegionService regionService;
 
     @Transactional(readOnly = true)
     public PageResponse<AdminStoreResponse> list(AdminSearchStoreRequest request) {
@@ -49,10 +52,11 @@ public class AdminStoreService {
     @Transactional
     public Long create(AdminCreateStoreRequest request) {
         User user = userService.findById(request.getOwnerId());
+        Region region = regionService.get(request.getRegionId());
 
         userAuthorityService.checkPermission(user.getAuthorities(), Role.CEO);
 
-        Store store = storeService.create(user, request.getName(), request.getCity(), request.getAddress(), request.getCategory(),
+        Store store = storeService.create(user, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(),
                 request.getDescription(), request.getPriceCategory(), request.getEventDescription(), request.getContactNumber(),
                 request.getDirection(), request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(),
                 request.getIsTakeOut(), request.getLatitude(), request.getLongitude());
@@ -64,7 +68,9 @@ public class AdminStoreService {
 
     @Transactional
     public void update(Long id, AdminUpdateStoreRequest request) {
-        storeService.update(id, request.getName(), request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
+        Region region = regionService.get(request.getRegionId());
+
+        storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
                 request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
                 request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude());
     }

--- a/fooding-api/src/main/java/im/fooding/app/service/app/store/AppStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/app/store/AppStoreService.java
@@ -1,15 +1,11 @@
 package im.fooding.app.service.app.store;
 
+import im.fooding.app.dto.request.app.store.AppSearchStoreRequest;
 import im.fooding.app.dto.response.app.store.AppStoreResponse;
-import im.fooding.core.common.BasicSearch;
-import im.fooding.core.common.PageInfo;
-import im.fooding.core.common.PageResponse;
-import im.fooding.core.model.store.Store;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,8 +19,8 @@ public class AppStoreService {
     private final StoreMemberService storeMemberService;
 
     @Transactional(readOnly = true)
-    public List<AppStoreResponse> list(long userId) {
-        return storeService.list(userId).stream().map(AppStoreResponse::from).toList();
+    public List<AppStoreResponse> list(long userId, AppSearchStoreRequest search) {
+        return storeService.list(userId, search.toStoreFilter()).stream().map(AppStoreResponse::from).toList();
     }
 
     @Transactional(readOnly = true)

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
@@ -1,6 +1,7 @@
 package im.fooding.app.service.ceo.store;
 
 import im.fooding.app.dto.request.ceo.store.CeoCreateStoreRequest;
+import im.fooding.app.dto.request.ceo.store.CeoSearchStoreRequest;
 import im.fooding.app.dto.request.ceo.store.CeoUpdateStoreRequest;
 import im.fooding.app.dto.response.ceo.store.CeoStoreResponse;
 import im.fooding.core.model.region.Region;
@@ -17,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,8 +29,10 @@ public class CeoStoreService {
     private final RegionService regionService;
 
     @Transactional(readOnly = true)
-    public List<CeoStoreResponse> list(long userId) {
-        return storeService.list(userId).stream().map(CeoStoreResponse::new).collect(Collectors.toList());
+    public List<CeoStoreResponse> list(long userId, CeoSearchStoreRequest search) {
+        return storeService.list(userId, search.toStoreFilter()).stream()
+                .map(CeoStoreResponse::new)
+                .toList();
     }
 
     @Transactional(readOnly = true)

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
@@ -3,9 +3,11 @@ package im.fooding.app.service.ceo.store;
 import im.fooding.app.dto.request.ceo.store.CeoCreateStoreRequest;
 import im.fooding.app.dto.request.ceo.store.CeoUpdateStoreRequest;
 import im.fooding.app.dto.response.ceo.store.CeoStoreResponse;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StorePosition;
 import im.fooding.core.model.user.User;
+import im.fooding.core.service.region.RegionService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
 import im.fooding.core.service.user.UserService;
@@ -24,6 +26,7 @@ public class CeoStoreService {
     private final StoreService storeService;
     private final StoreMemberService storeMemberService;
     private final UserService userService;
+    private final RegionService regionService;
 
     @Transactional(readOnly = true)
     public List<CeoStoreResponse> list(long userId) {
@@ -39,8 +42,9 @@ public class CeoStoreService {
     @Transactional
     public Long create(CeoCreateStoreRequest request, long userId) {
         User user = userService.findById(userId);
+        Region region = regionService.get(request.getRegionId());
 
-        Store store = storeService.create(user, request.getName(), request.getCity(), request.getAddress(), request.getCategory(),
+        Store store = storeService.create(user, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(),
                 request.getDescription(), request.getPriceCategory(), request.getEventDescription(), request.getContactNumber(),
                 request.getDirection(), request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(),
                 request.getIsTakeOut(), request.getLatitude(), request.getLongitude());
@@ -53,7 +57,9 @@ public class CeoStoreService {
     @Transactional
     public void update(Long id, CeoUpdateStoreRequest request, long userId) {
         storeMemberService.checkMember(id, userId);
-        storeService.update(id, request.getName(), request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
+        Region region = regionService.get(request.getRegionId());
+
+        storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
                 request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
                 request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude());
     }

--- a/fooding-core/src/main/java/im/fooding/core/dto/request/store/StoreFilter.java
+++ b/fooding-core/src/main/java/im/fooding/core/dto/request/store/StoreFilter.java
@@ -1,0 +1,8 @@
+package im.fooding.core.dto.request.store;
+
+import lombok.Value;
+
+@Value
+public class StoreFilter {
+    String regionId;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
@@ -1,8 +1,20 @@
 package im.fooding.core.model.store;
 
 import im.fooding.core.model.BaseEntity;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.user.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,9 +22,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
-
-import java.math.BigDecimal;
-import java.util.List;
 
 @Entity
 @Getter
@@ -29,6 +38,10 @@ public class Store extends BaseEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Region region;
 
     @Column(name = "city", nullable = false)
     private String city;
@@ -84,11 +97,28 @@ public class Store extends BaseEntity {
     private List<StoreImage> images;
 
     @Builder
-    private Store(User owner, String name, String city, String address, String category, String description, String contactNumber,
-                  String priceCategory, String eventDescription, String direction, String information, boolean isParkingAvailable,
-                  boolean isNewOpen, boolean isTakeOut, Double latitude, Double longitude) {
+    private Store(
+            User owner,
+            String name,
+            Region region,
+            String city,
+            String address,
+            String category,
+            String description,
+            String contactNumber,
+            String priceCategory,
+            String eventDescription,
+            String direction,
+            String information,
+            boolean isParkingAvailable,
+            boolean isNewOpen,
+            boolean isTakeOut,
+            Double latitude,
+            Double longitude
+    ) {
         this.owner = owner;
         this.name = name;
+        this.region = region;
         this.city = city;
         this.address = address;
         this.category = category;
@@ -105,10 +135,26 @@ public class Store extends BaseEntity {
         this.longitude = longitude;
     }
 
-    public void update(String name, String city, String address, String category, String description, String contactNumber,
-                       String priceCategory, String eventDescription, String direction, String information, boolean isParkingAvailable,
-                       boolean isNewOpen, boolean isTakeOut, Double latitude, Double longitude) {
+    public void update(
+            String name,
+            Region region,
+            String city,
+            String address,
+            String category,
+            String description,
+            String contactNumber,
+            String priceCategory,
+            String eventDescription,
+            String direction,
+            String information,
+            boolean isParkingAvailable,
+            boolean isNewOpen,
+            boolean isTakeOut,
+            Double latitude,
+            Double longitude
+    ) {
         this.name = name;
+        this.region = region;
         this.city = city;
         this.address = address;
         this.category = category;

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepository.java
@@ -1,5 +1,6 @@
 package im.fooding.core.repository.store;
 
+import im.fooding.core.dto.request.store.StoreFilter;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreSortType;
 import org.hibernate.query.SortDirection;
@@ -18,7 +19,7 @@ public interface QStoreRepository {
             boolean includeDeleted
     );
 
-    List<Store> listByUserId(long userId);
+    List<Store> listByUserId(long userId, StoreFilter filter);
 
     Optional<Store> retrieve(long storeId);
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.dto.request.store.StoreFilter;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreSortType;
 import lombok.RequiredArgsConstructor;
@@ -55,12 +56,16 @@ public class QStoreRepositoryImpl implements QStoreRepository {
     }
 
     @Override
-    public List<Store> listByUserId(long userId) {
+    public List<Store> listByUserId(long userId, StoreFilter filter) {
         return query
                 .select(store)
                 .from(store)
                 .innerJoin(storeMember).on(store.id.eq(storeMember.store.id))
-                .where(storeMember.user.id.eq(userId), store.deleted.isFalse())
+                .where(
+                        storeMember.user.id.eq(userId),
+                        regionIdEq(filter.getRegionId()),
+                        store.deleted.isFalse()
+                )
                 .orderBy(store.id.desc())
                 .fetch();
     }
@@ -96,5 +101,9 @@ public class QStoreRepositoryImpl implements QStoreRepository {
 
     private BooleanExpression storeImageDeletedIfExists() {
         return storeImage.id.isNull().or(storeImage.deleted.isFalse());
+    }
+
+    private BooleanExpression regionIdEq(String regionId) {
+        return regionId != null ? store.region.id.eq(regionId) : null;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -1,5 +1,6 @@
 package im.fooding.core.service.store;
 
+import im.fooding.core.dto.request.store.StoreFilter;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.region.Region;
@@ -40,8 +41,8 @@ public class StoreService {
      * @param userId
      * @return List<Store>
      */
-    public List<Store> list(long userId) {
-        return storeRepository.listByUserId(userId);
+    public List<Store> list(long userId, StoreFilter filter) {
+        return storeRepository.listByUserId(userId, filter);
     }
 
     /**

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -2,6 +2,7 @@ package im.fooding.core.service.store;
 
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreSortType;
 import im.fooding.core.model.user.User;
@@ -68,12 +69,29 @@ public class StoreService {
     /**
      * 가게 생성
      */
-    public Store create(User owner, String name, String city, String address, String category, String description,
-                        String priceCategory, String eventDescription, String contactNumber, String direction,
-                        String information, boolean isParkingAvailable, boolean isNewOpen, boolean isTakeOut, Double latitude, Double longitude) {
+    public Store create(
+            User owner,
+            String name,
+            Region region,
+            String city,
+            String address,
+            String category,
+            String description,
+            String priceCategory,
+            String eventDescription,
+            String contactNumber,
+            String direction,
+            String information,
+            boolean isParkingAvailable,
+            boolean isNewOpen,
+            boolean isTakeOut,
+            Double latitude,
+            Double longitude
+    ) {
         Store store = Store.builder()
                 .owner(owner)
                 .name(name)
+                .region(region)
                 .city(city)
                 .address(address)
                 .category(category)
@@ -92,11 +110,27 @@ public class StoreService {
         return storeRepository.save(store);
     }
 
-    public void update(long id, String name, String city, String address, String category, String description,
-                       String contactNumber, String priceCategory, String eventDescription, String direction,
-                       String information, boolean isParkingAvailable, boolean isNewOpen, boolean isTakeOut, Double latitude, Double longitude) {
+    public void update(
+            long id,
+            String name,
+            Region region,
+            String city,
+            String address,
+            String category,
+            String description,
+            String contactNumber,
+            String priceCategory,
+            String eventDescription,
+            String direction,
+            String information,
+            boolean isParkingAvailable,
+            boolean isNewOpen,
+            boolean isTakeOut,
+            Double latitude,
+            Double longitude
+    ) {
         Store store = findById(id);
-        store.update(name, city, address, category, description, contactNumber, priceCategory, eventDescription,
+        store.update(name, region, city, address, category, description, contactNumber, priceCategory, eventDescription,
                 direction, information, isParkingAvailable, isNewOpen, isTakeOut, latitude, longitude);
     }
 

--- a/fooding-core/src/test/java/im/fooding/core/service/coupon/CouponServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/coupon/CouponServiceTest.java
@@ -5,8 +5,10 @@ import im.fooding.core.common.BasicSearch;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.coupon.*;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.repository.coupon.CouponRepository;
+import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,9 @@ class CouponServiceTest extends TestConfig {
 
     @Autowired
     StoreRepository storeRepository;
+
+    @Autowired
+    RegionRepository regionRepository;
 
     @Test
     @DisplayName("쿠폰을 성공적으로 등록한다.")
@@ -193,6 +198,7 @@ class CouponServiceTest extends TestConfig {
     private Store saveStore() {
         Store store = Store.builder()
                 .name("테스트가게")
+                .region(saveRegion())
                 .city("테스트")
                 .address("테스트")
                 .category("테스트")
@@ -221,5 +227,19 @@ class CouponServiceTest extends TestConfig {
                 .status(CouponStatus.ACTIVE)
                 .build();
         return couponRepository.save(coupon);
+    }
+
+    private Region saveRegion() {
+        Region region = Region.builder()
+                .id("테스트")
+                .parentRegion(null)
+                .name("테스트")
+                .timezone("테스트")
+                .countryCode("테스트")
+                .legalCode("테스트")
+                .currency("테스트")
+                .level(1)
+                .build();
+        return regionRepository.save(region);
     }
 }

--- a/fooding-core/src/test/java/im/fooding/core/service/coupon/UserCouponServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/coupon/UserCouponServiceTest.java
@@ -5,10 +5,12 @@ import im.fooding.core.common.BasicSearch;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.coupon.*;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.user.*;
 import im.fooding.core.repository.coupon.CouponRepository;
 import im.fooding.core.repository.coupon.UserCouponRepository;
+import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
 import im.fooding.core.repository.user.UserAuthorityRepository;
 import im.fooding.core.repository.user.UserRepository;
@@ -43,6 +45,9 @@ class UserCouponServiceTest extends TestConfig {
 
     @Autowired
     UserAuthorityRepository userAuthorityRepository;
+
+    @Autowired
+    RegionRepository regionRepository;
 
     @Test
     @DisplayName("유저에게 쿠폰을 성공적으로 발급한다.")
@@ -206,6 +211,7 @@ class UserCouponServiceTest extends TestConfig {
     private Store saveStore() {
         Store store = Store.builder()
                 .name("테스트가게")
+                .region(saveRegion())
                 .city("테스트")
                 .address("테스트")
                 .category("테스트")
@@ -250,4 +256,17 @@ class UserCouponServiceTest extends TestConfig {
         return userCouponRepository.save(userCoupon);
     }
 
+    private Region saveRegion() {
+        Region region = Region.builder()
+                .id("테스트")
+                .parentRegion(null)
+                .name("테스트")
+                .timezone("테스트")
+                .countryCode("테스트")
+                .legalCode("테스트")
+                .currency("테스트")
+                .level(1)
+                .build();
+        return regionRepository.save(region);
+    }
 }

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/StoreWaitingServiceTest.java
@@ -10,12 +10,14 @@ import im.fooding.core.TestConfig;
 import im.fooding.core.dto.request.waiting.StoreWaitingRegisterRequest;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.StoreWaitingChannel;
 import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingStatus;
 import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
 import im.fooding.core.repository.waiting.StoreWaitingRepository;
 import im.fooding.core.repository.waiting.WaitingRepository;
@@ -23,6 +25,7 @@ import im.fooding.core.common.BasicSearch;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
 import im.fooding.core.model.waiting.StoreWaitingStatus;
 import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.RegionDummy;
 import im.fooding.core.support.dummy.StoreDummy;
 import im.fooding.core.support.dummy.StoreWaitingDummy;
 import im.fooding.core.support.dummy.WaitingUserDummy;
@@ -44,6 +47,7 @@ class StoreWaitingServiceTest extends TestConfig {
     private final StoreRepository storeRepository;
     private final WaitingUserRepository waitingUserRepository;
     private final WaitingRepository waitingRepository;
+    private final RegionRepository regionRepository;
 
     @AfterEach
     void tearDown() {
@@ -51,13 +55,15 @@ class StoreWaitingServiceTest extends TestConfig {
         storeRepository.deleteAll();
         waitingUserRepository.deleteAll();
         waitingRepository.deleteAll();
+        regionRepository.deleteAll();
     }
 
     @Test
     @DisplayName("가게 id로 특정 상태의 가게의 웨이팅을 모두 가져올 수 있다.")
     void  get_all_store_waiting_with_specific_status() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser waitingUser = waitingUserRepository.save(WaitingUserDummy.create(store));
 
         StoreWaiting storeWaiting = StoreWaiting.builder()
@@ -132,7 +138,8 @@ class StoreWaitingServiceTest extends TestConfig {
     @DisplayName("웨이팅을 조회할 수 있다.")
     public void testGetStoreWaiting() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
         StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
 
@@ -157,7 +164,8 @@ class StoreWaitingServiceTest extends TestConfig {
     @DisplayName("웨이팅 등록시 가게의 현재 웨이팅 개수 + 1의 호출 번호로 등록된다.")
     public void callNumber_is_current_waiting_count_plus_1_when_register() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser user1 = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01012345678"));
         WaitingUser user2 = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01023456789"));
 
@@ -194,7 +202,8 @@ class StoreWaitingServiceTest extends TestConfig {
     @DisplayName("웨이팅이 오픈 상태인 경우를 검증에 성공한다.")
     public void validate_when_opened() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         Waiting waiting = waitingRepository.save(new Waiting(store, WaitingStatus.WAITING_OPEN));
 
         // when & then
@@ -206,7 +215,8 @@ class StoreWaitingServiceTest extends TestConfig {
     @DisplayName("웨이팅이 오픈 상태가 아닌 경우를 검증에 실패한다.")
     public void validate_when_not_opened() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         Waiting waiting = waitingRepository.save(new Waiting(store, WaitingStatus.PAUSED));
 
         // when & then
@@ -223,7 +233,8 @@ class StoreWaitingServiceTest extends TestConfig {
     @DisplayName("웨이팅을 취소할 수 있다.")
     public void testCancel() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
         StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
 
@@ -239,7 +250,8 @@ class StoreWaitingServiceTest extends TestConfig {
     @DisplayName("가게 웨이팅을 착석 처리할 수 있다.")
     public void testSeat() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
         StoreWaiting storeWaiting = storeWaitingRepository.save(spy(StoreWaitingDummy.create(user, store)));
 
@@ -254,7 +266,8 @@ class StoreWaitingServiceTest extends TestConfig {
     @DisplayName("호출시 호출 횟수를 증가한다.")
     public void testCall() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser user = waitingUserRepository.save(WaitingUserDummy.create(store));
         StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
 

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingLogServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingLogServiceTest.java
@@ -3,15 +3,18 @@ package im.fooding.core.service.waiting;
 import static org.junit.jupiter.api.Assertions.*;
 
 import im.fooding.core.TestConfig;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.WaitingLog;
 import im.fooding.core.model.waiting.WaitingLogType;
 import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
 import im.fooding.core.repository.waiting.StoreWaitingRepository;
 import im.fooding.core.repository.waiting.WaitingLogRepository;
 import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.RegionDummy;
 import im.fooding.core.support.dummy.StoreDummy;
 import im.fooding.core.support.dummy.StoreWaitingDummy;
 import im.fooding.core.support.dummy.WaitingUserDummy;
@@ -34,6 +37,7 @@ class WaitingLogServiceTest extends TestConfig {
     private final WaitingUserRepository waitingUserRepository;
     private final StoreRepository storeRepository;
     private final StoreWaitingRepository storeWaitingRepository;
+    private final RegionRepository regionRepository;
 
     @AfterEach
     void tearDown() {
@@ -41,13 +45,15 @@ class WaitingLogServiceTest extends TestConfig {
         waitingUserRepository.deleteAll();
         storeRepository.deleteAll();
         storeWaitingRepository.deleteAll();
+        regionRepository.deleteAll();
     }
 
     @Test
     @DisplayName("register 로그를 남기면 WAITING_REGISTRATION 으로 로그가 남아야 한다.")
     public void save_WAITING_REGISTRATION_when_log_register() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser user = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01012345678"));
         StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
 
@@ -67,7 +73,8 @@ class WaitingLogServiceTest extends TestConfig {
     @DisplayName("특정 가게 웨이팅과 관련된 로그를 모두 조회할 수 있다.")
     public void testList() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser user = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01012345678"));
         StoreWaiting storeWaiting = storeWaitingRepository.save(StoreWaitingDummy.create(user, store));
         List<WaitingLog> waitingLogs = List.of(

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingServiceTest.java
@@ -7,11 +7,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import im.fooding.core.TestConfig;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingStatus;
+import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
 import im.fooding.core.repository.waiting.WaitingRepository;
+import im.fooding.core.support.dummy.RegionDummy;
 import im.fooding.core.support.dummy.StoreDummy;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
@@ -26,18 +29,21 @@ class WaitingServiceTest extends TestConfig {
     private final WaitingService waitingService;
     private final WaitingRepository waitingRepository;
     private final StoreRepository storeRepository;
+    private final RegionRepository regionRepository;
 
     @AfterEach
     void tearDown() {
         waitingRepository.deleteAll();
         storeRepository.deleteAll();
+        regionRepository.deleteAll();
     }
 
     @Test
     @DisplayName("id를 통해 웨이팅을 조회할 수 있다.")
     public void get_waiting_by_id() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         Waiting waiting = waitingRepository.save(new Waiting(store, WaitingStatus.WAITING_OPEN));
 
         // when & then

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingSettingServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingSettingServiceTest.java
@@ -6,12 +6,15 @@ import im.fooding.core.TestConfig;
 import im.fooding.core.dto.request.waiting.WaitingSettingCreateRequest;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.Waiting;
 import im.fooding.core.model.waiting.WaitingSetting;
+import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
 import im.fooding.core.repository.waiting.WaitingRepository;
 import im.fooding.core.repository.waiting.WaitingSettingRepository;
+import im.fooding.core.support.dummy.RegionDummy;
 import im.fooding.core.support.dummy.StoreDummy;
 import im.fooding.core.support.dummy.WaitingDummy;
 import im.fooding.core.support.dummy.WaitingSettingDummy;
@@ -30,19 +33,22 @@ class WaitingSettingServiceTest extends TestConfig {
     private final WaitingSettingRepository waitingSettingRepository;
     private final WaitingRepository waitingRepository;
     private final StoreRepository storeRepository;
+    private final RegionRepository regionRepository;
 
     @AfterEach
     void tearDown() {
         waitingSettingRepository.deleteAll();
         waitingRepository.deleteAll();
         storeRepository.deleteAll();
+        regionRepository.deleteAll();
     }
 
     @Test
     @DisplayName("활성화된 웨이팅 세팅을 조회할 수 있다.")
     public void testGetActive() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         Waiting waiting = waitingRepository.save(WaitingDummy.create(store));
         waitingSettingRepository.save(WaitingSettingDummy.create(waiting, true));
 
@@ -58,7 +64,8 @@ class WaitingSettingServiceTest extends TestConfig {
     @DisplayName("활성화된 웨이팅 세팅이 존재하지 않는 경우 활성 웨이팅 세팅을 조회할 수 없다.")
     public void testGetActive_fail_whenNotFoundActiveSetting() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         Waiting waiting = waitingRepository.save(WaitingDummy.create(store));
         waitingSettingRepository.save(WaitingSettingDummy.create(waiting, false));
 
@@ -72,7 +79,8 @@ class WaitingSettingServiceTest extends TestConfig {
     @DisplayName("웨이팅 세팅을 생성할 수 있다.")
     public void testCreate() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         Waiting waiting = waitingRepository.save(WaitingDummy.create(store));
         WaitingSettingCreateRequest request = WaitingSettingCreateRequest.builder()
                 .waiting(waiting)
@@ -93,7 +101,8 @@ class WaitingSettingServiceTest extends TestConfig {
     @DisplayName("이미 활성화된 웨이팅 세팅이 존재하는 경우 활성 웨이팅 세팅을 생성할 수 없다.")
     public void testCreate_fail_whenAlreadyExistActiveWaitingSetting() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         Waiting waiting = waitingRepository.save(WaitingDummy.create(store));
         WaitingSettingCreateRequest request = WaitingSettingCreateRequest.builder()
                 .waiting(waiting)

--- a/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingUserServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/waiting/WaitingUserServiceTest.java
@@ -2,10 +2,13 @@ package im.fooding.core.service.waiting;
 
 import im.fooding.core.TestConfig;
 import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.waiting.WaitingUser;
+import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
 import im.fooding.core.repository.waiting.WaitingUserRepository;
+import im.fooding.core.support.dummy.RegionDummy;
 import im.fooding.core.support.dummy.StoreDummy;
 import im.fooding.core.support.dummy.WaitingUserDummy;
 import lombok.RequiredArgsConstructor;
@@ -22,18 +25,21 @@ class WaitingUserServiceTest extends TestConfig {
     private final WaitingUserService waitingUserService;
     private final WaitingUserRepository waitingUserRepository;
     private final StoreRepository storeRepository;
+    private final RegionRepository regionRepository;
 
     @AfterEach
     void tearDown() {
         waitingUserRepository.deleteAll();
         storeRepository.deleteAll();
+        regionRepository.deleteAll();
     }
 
     @Test
     @DisplayName("웨이팅 유저가 없는 경우 새로 등록한다.")
     void register_when_not_exist_waiting_user() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
 
         WaitingUserRegisterRequest request = WaitingUserRegisterRequest.builder()
                 .store(store)
@@ -56,7 +62,8 @@ class WaitingUserServiceTest extends TestConfig {
     @DisplayName("웨이팅 유저가 있다면 존재하는 유저를 가져온다.")
     void get_when_exist_waiting_user() {
         // given
-        Store store = storeRepository.save(StoreDummy.create());
+        Region region = regionRepository.save(RegionDummy.create());
+        Store store = storeRepository.save(StoreDummy.create(region));
         WaitingUser waitingUser = waitingUserRepository.save(WaitingUserDummy.createWithPhoneNumber(store, "01012345678"));
 
         WaitingUserRegisterRequest request = WaitingUserRegisterRequest.builder()

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/RegionDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/RegionDummy.java
@@ -1,0 +1,19 @@
+package im.fooding.core.support.dummy;
+
+import im.fooding.core.model.region.Region;
+
+public class RegionDummy {
+
+    public static Region create() {
+        return Region.builder()
+                .id("테스트")
+                .parentRegion(null)
+                .name("테스트")
+                .timezone("테스트")
+                .countryCode("테스트")
+                .legalCode("테스트")
+                .currency("테스트")
+                .level(1)
+                .build();
+    }
+}

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
@@ -1,5 +1,6 @@
 package im.fooding.core.support.dummy;
 
+import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 
 public class StoreDummy {
@@ -7,6 +8,25 @@ public class StoreDummy {
     public static Store create() {
         return Store.builder()
                 .name("name")
+                .city("city")
+                .address("address")
+                .category("category")
+                .description("description")
+                .contactNumber("01012345678")
+                .priceCategory("priceCategory")
+                .eventDescription("eventDescription")
+                .direction("direction")
+                .information("information")
+                .isParkingAvailable(true)
+                .isNewOpen(true)
+                .isTakeOut(true)
+                .build();
+    }
+
+    public static Store create(Region region) {
+        return Store.builder()
+                .name("name")
+                .region(region)
                 .city("city")
                 .address("address")
                 .category("category")


### PR DESCRIPTION
## 관련 이슈
- [Store 에 regionId  저장 및 API 수정](https://www.notion.so/benkang/Store-regionId-API-21f83feabad380af9089ed929bf90e92?source=copy_link)

## 주요 변경 사항
- 가게 도메인에 지역 추가
  - 가게 도메인에 지역 컬럼 not null로 추가
  - 기존 CEO API 에서 Store 생성, 수정 및 조회시 regionId 생성, 수정 및 조회할 수 있도록 변경
  - 기존 ADMIN API 에서 Store 생성, 수정 및 조회시 regionId 생성, 수정 및 조회할 수 있도록 변경
- CEO, APP 가게 조회시 지역 ID 필터링 추가
- 도메인 의존성 변경으로 인한 테스트 수정
  - 테스트 성공을 위해 테스트 코드를 수정했지만 의미 있는 수정은 없이 도메인 의존성 변경으로 인한 테스트 수정만 진행했습니다.