### PR TITLE
[BE-226] Store에 인근 지하철역 자동 탐색 후 추가 기능 구현

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
@@ -66,9 +66,11 @@ public class AdminCreateStoreRequest {
     @Schema(description = "포장가능여부", example = "true")
     private Boolean isTakeOut;
 
+    @NotNull(message = "위도 값은 필수입니다.")
     @Schema(description = "위도", example = "36.40947226931638")
     private Double latitude;
 
+    @NotNull(message = "경도 값은 필수입니다.")
     @Schema(description = "경도", example = "127.12345678901234")
     private Double longitude;
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
@@ -62,9 +62,11 @@ public class AdminUpdateStoreRequest {
     @Schema(description = "포장가능여부", example = "true")
     private Boolean isTakeOut;
 
+    @NotNull(message = "위도 값은 필수입니다.")
     @Schema(description = "위도", example = "36.40947226931638")
     private Double latitude;
 
+    @NotNull(message = "경도 값은 필수입니다.")
     @Schema(description = "경도", example = "127.12345678901234")
     private Double longitude;
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoUpdateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoUpdateStoreRequest.java
@@ -64,9 +64,11 @@ public class CeoUpdateStoreRequest {
     @Schema(description = "포장가능여부", example = "true")
     private Boolean isTakeOut;
 
+    @NotNull(message = "위도 값은 필수입니다.")
     @Schema(description = "위도", example = "36.40947226931638")
     private Double latitude;
 
+    @NotNull(message = "경도 값은 필수입니다.")
     @Schema(description = "경도", example = "127.12345678901234")
     private Double longitude;
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/admin/store/AdminStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/admin/store/AdminStoreResponse.java
@@ -2,11 +2,16 @@ package im.fooding.app.dto.response.admin.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.subway.SubwayStation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
 
 @Getter
+@Setter
 public class AdminStoreResponse {
     @Schema(description = "id", example = "1", requiredMode = RequiredMode.REQUIRED)
     private final Long id;
@@ -65,6 +70,9 @@ public class AdminStoreResponse {
     @Schema(description = "경도", example = "127.12345678901234", requiredMode = RequiredMode.NOT_REQUIRED)
     private final Double longitude;
 
+    @Schema(description = "인근 지하철역")
+    private List<SubwayStation> stations;
+
     public AdminStoreResponse(Store store) {
         this.id = store.getId();
         this.ownerId = store.getOwner() != null ? store.getOwner().getId() : null;
@@ -84,5 +92,6 @@ public class AdminStoreResponse {
         this.isTakeOut = store.isTakeOut();
         this.latitude = store.getLatitude();
         this.longitude = store.getLongitude();
+        this.stations = store.getSubwayStations();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreResponse.java
@@ -2,9 +2,12 @@ package im.fooding.app.dto.response.ceo.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.subway.SubwayStation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class CeoStoreResponse {
@@ -74,6 +77,9 @@ public class CeoStoreResponse {
     @Schema(description = "해당 가게의 총 관심 수", example = "100", requiredMode = RequiredMode.REQUIRED)
     private final int bookmarkCount;
 
+    @Schema(description = "인근 지하철역", example="홍대입구역 2호선", requiredMode = RequiredMode.REQUIRED)
+    private final List<SubwayStation> stations;
+
     public CeoStoreResponse(Store store) {
         this.id = store.getId();
         this.ownerId = store.getOwner() != null ? store.getOwner().getId() : null;
@@ -96,5 +102,6 @@ public class CeoStoreResponse {
         this.visitCount = store.getVisitCount();
         this.reviewCount = store.getReviewCount();
         this.bookmarkCount = store.getBookmarkCount();
+        this.stations = store.getSubwayStations();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
@@ -9,11 +9,13 @@ import im.fooding.core.common.PageResponse;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StorePosition;
+import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.Role;
 import im.fooding.core.model.user.User;
 import im.fooding.core.service.region.RegionService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
+import im.fooding.core.service.store.subway.SubwayStationService;
 import im.fooding.core.service.user.UserAuthorityService;
 import im.fooding.core.service.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -33,6 +36,7 @@ public class AdminStoreService {
     private final UserService userService;
     private final UserAuthorityService userAuthorityService;
     private final RegionService regionService;
+    private final SubwayStationService subwayStationService;
 
     @Transactional(readOnly = true)
     public PageResponse<AdminStoreResponse> list(AdminSearchStoreRequest request) {
@@ -70,9 +74,11 @@ public class AdminStoreService {
     public void update(Long id, AdminUpdateStoreRequest request) {
         Region region = regionService.get(request.getRegionId());
 
+        List<SubwayStation> nearStations = subwayStationService.getNearStations( request.getLatitude(), request.getLongitude() );
+
         storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
                 request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
-                request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude());
+                request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude(), nearStations);
     }
 
     @Transactional

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
@@ -7,16 +7,19 @@ import im.fooding.app.dto.response.ceo.store.CeoStoreResponse;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StorePosition;
+import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.User;
 import im.fooding.core.service.region.RegionService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
+import im.fooding.core.service.store.subway.SubwayStationService;
 import im.fooding.core.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -27,6 +30,7 @@ public class CeoStoreService {
     private final StoreMemberService storeMemberService;
     private final UserService userService;
     private final RegionService regionService;
+    private final SubwayStationService subwayStationService;
 
     @Transactional(readOnly = true)
     public List<CeoStoreResponse> list(long userId, CeoSearchStoreRequest search) {
@@ -58,11 +62,13 @@ public class CeoStoreService {
         storeMemberService.checkMember(id, userId);
         Region region = regionService.get(request.getRegionId());
 
+        // 주소를 통해 인근 지하철역 조회 ( 1km 반경 내 )
+        List<SubwayStation> nearStations = subwayStationService.getNearStations( request.getLatitude(), request.getLongitude() );
+
         storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
                 request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
-                request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude());
+                request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude(), nearStations);
     }
-
     @Transactional
     public void delete(Long id, long deletedBy) {
         storeMemberService.checkMember(id, deletedBy);

--- a/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
@@ -2,18 +2,10 @@ package im.fooding.core.model.store;
 
 import im.fooding.core.model.BaseEntity;
 import im.fooding.core.model.region.Region;
+import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -86,6 +78,10 @@ public class Store extends BaseEntity {
 
     private double averageRating;
 
+    @Column(nullable = false)
+    @ManyToMany(fetch = FetchType.EAGER)
+    private List<SubwayStation> subwayStations;
+
     private Double latitude;
 
     private Double longitude;
@@ -133,6 +129,7 @@ public class Store extends BaseEntity {
         this.isTakeOut = isTakeOut;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.subwayStations = null;
     }
 
     public void update(
@@ -193,5 +190,9 @@ public class Store extends BaseEntity {
 
     public void decreaseBookmarkCount() {
         this.bookmarkCount--;
+    }
+
+    public void setNearSubwayStations(List<SubwayStation> stations){
+        this.subwayStations = stations;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/store/subway/Document.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/subway/Document.java
@@ -1,0 +1,21 @@
+package im.fooding.core.model.store.subway;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Document {
+    private String id;
+    private String place_name;
+    private String category_name;
+    private String category_group_code;
+    private String category_group_name;
+    private String phone;
+    private String address_name;
+    private String road_address_name;
+    private String x;  // 경도
+    private String y;  // 위도
+    private String place_url;
+    private String distance;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/subway/KakaoMapResponse.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/subway/KakaoMapResponse.java
@@ -1,0 +1,13 @@
+package im.fooding.core.model.store.subway;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class KakaoMapResponse {
+    private Meta meta;
+    private List<Document> documents;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/subway/Meta.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/subway/Meta.java
@@ -1,0 +1,13 @@
+package im.fooding.core.model.store.subway;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Meta {
+    private int total_count;
+    private int pageable_count;
+    private boolean is_end;
+    private Object same_name;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/subway/SubwayStation.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/subway/SubwayStation.java
@@ -1,0 +1,41 @@
+package im.fooding.core.model.store.subway;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.transaction.annotation.Transactional;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class SubwayStation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="name")
+    private String name;
+
+    @Column(name="line")
+    private String line;
+
+    @Column(name="address")
+    private String address;
+
+    @Builder
+    private SubwayStation( String name, String line, String address ){
+        this.name = name;
+        this.line = line;
+        this.address = address;
+    }
+
+    @Transactional
+    public void update( String stationName ){
+        this.name = stationName;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/subway/SubwayStationRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/subway/SubwayStationRepository.java
@@ -1,0 +1,8 @@
+package im.fooding.core.repository.store.subway;
+
+import im.fooding.core.model.store.subway.SubwayStation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubwayStationRepository extends JpaRepository<SubwayStation, Long> {
+    SubwayStation findByNameAndLine( String name, String line );
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -6,6 +6,7 @@ import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreSortType;
+import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.User;
 import im.fooding.core.repository.store.StoreRepository;
 import lombok.RequiredArgsConstructor;
@@ -128,11 +129,13 @@ public class StoreService {
             boolean isNewOpen,
             boolean isTakeOut,
             Double latitude,
-            Double longitude
+            Double longitude,
+            List<SubwayStation> stations
     ) {
         Store store = findById(id);
         store.update(name, region, city, address, category, description, contactNumber, priceCategory, eventDescription,
                 direction, information, isParkingAvailable, isNewOpen, isTakeOut, latitude, longitude);
+        store.setNearSubwayStations( stations );
     }
 
     public void delete(long id, Long deletedBy) {

--- a/fooding-core/src/main/java/im/fooding/core/service/store/subway/SubwayStationService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/subway/SubwayStationService.java
@@ -1,0 +1,80 @@
+package im.fooding.core.service.store.subway;
+
+import im.fooding.core.model.store.subway.Document;
+import im.fooding.core.model.store.subway.KakaoMapResponse;
+import im.fooding.core.model.store.subway.SubwayStation;
+import im.fooding.core.repository.store.subway.SubwayStationRepository;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+@Getter
+@Slf4j
+public class SubwayStationService {
+    private final SubwayStationRepository repository;
+
+    // 추후 환경 변수로 등록
+    private final String KAKAO_MAP_API_BASE_URL = "https://dapi.kakao.com/v2/local";
+    private final String KAKAO_API_KEY = "b3ad5d14b4171350a56dac59bf037bd7";
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final int FIND_COUNTS = 3;
+    private final int FIND_RANGE = 1000;    // m 단위
+
+    private SubwayStation create( String name, String line, String address ){
+        SubwayStation station = SubwayStation.builder()
+                .name( name )
+                .line( line )
+                .address( address )
+                .build();
+        return repository.save( station );
+    }
+
+    public SubwayStation findStation( String name, String line ){
+        return repository.findByNameAndLine( name, line );
+    }
+
+    public List<SubwayStation> getNearStations(double latitude, double longitude ){
+        String url = KAKAO_MAP_API_BASE_URL + "/search/category.json";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + KAKAO_API_KEY);
+        headers.set("Content-Type", "application/json");
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("category_group_code", "SW8")
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", FIND_RANGE)
+                .queryParam("size", FIND_COUNTS);
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoMapResponse> response = restTemplate.exchange(
+                builder.toUriString(),
+                HttpMethod.GET,
+                entity,
+                KakaoMapResponse.class
+        );
+        List<SubwayStation> stations = new ArrayList<SubwayStation>();
+        for( Document stationInfo : response.getBody().getDocuments() ){
+            String[] stationName = stationInfo.getPlace_name().split(" ");
+            SubwayStation station = this.findStation( stationName[0], stationName[1] );
+            if( station == null ) station = this.create( stationName[0], stationName[1], stationInfo.getRoad_address_name() );
+            stations.add( station );
+        }
+        return stations;
+    }
+
+}


### PR DESCRIPTION
**<백로그>**
[BE-226](https://www.notion.so/benkang/Store-22483feabad380e1a0edccc21d73b3f1?source=copy_link)

**<구현 기능>**
- Store 도메인에 stations 필드 추가 ( ManyToMany로 n개의 Store에 m개의 지하철역이 연결될 수 있음 )
- SubwayStation 도메인 추가
    > 추후 지하철역 기준 검색 및 정렬에 용이하게 만들기 위해
- Store를 추가할 때 좌표( 위도, 경도 )를 기준으로 카카오맵 API를 통해 인근 1km 반경 내에 지하철역을 최대 3개까지 탐색해 추가
    > 없을 경우 추가하지 않음
    > SubwayStation 데이터를 따로 추가하지 않아도 주소가 변경될 때 기존에 만들어진 지하철역 데이터가 DB에 없으면 자동 생성, 있으면 생성하지 않음
- 가게 조회 시 해당 가게의 인근 지하철역 정보를 가져오도록 변경
    > List의 형태로 조회 -> 프론트에서 조회시 stations 라는 필드명으로 전달
- 카카오맵 API 조회를 위한 Documents, Meta, KakaoMapResponse 객체 생성

@titaniper 확인 부탁드립니다 :)