### PR TITLE
USER 추상화된 웨이팅 리스트 조회 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/app/waiting/AppWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/app/waiting/AppWaitingController.java
@@ -2,6 +2,7 @@ package im.fooding.app.controller.app.waiting;
 
 import im.fooding.app.dto.request.app.waiting.AppWaitingListRequest;
 import im.fooding.app.dto.request.app.waiting.AppWaitingRegisterRequest;
+import im.fooding.app.dto.request.app.waiting.AppWaitingReservationRequest;
 import im.fooding.app.dto.response.app.waiting.*;
 import im.fooding.app.service.app.waiting.AppWaitingApplicationService;
 import im.fooding.core.common.ApiResult;
@@ -89,5 +90,14 @@ public class AppWaitingController {
         @PathVariable long storeId
     ){
         return ApiResult.ok( appWaitingApplicationService.waitingStatus( storeId ) );
+    }
+
+    @GetMapping("/reservations")
+    @Operation(summary = "예약/웨이팅 목록 조회")
+    ApiResult<PageResponse<AppWaitingReservationResponse>> getReservations(
+            @AuthenticationPrincipal UserInfo userInfo,
+            @ModelAttribute AppWaitingReservationRequest request
+    ) {
+        return ApiResult.ok(appWaitingApplicationService.getReservations(request, userInfo.getId()));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/app/waiting/AppWaitingReservationRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/app/waiting/AppWaitingReservationRequest.java
@@ -1,0 +1,22 @@
+package im.fooding.app.dto.request.app.waiting;
+
+import im.fooding.core.common.BasicSearch;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+@Value
+public class AppWaitingReservationRequest extends BasicSearch {
+
+    @Schema(description = "방문 상태 (SCHEDULED, COMPLETED, NOT_VISITED)", requiredMode = RequiredMode.REQUIRED, example = "SCHEDULED")
+    VisitStatus visitStatus;
+
+    @RequiredArgsConstructor
+    public enum VisitStatus {
+        SCHEDULED,      // 방문예정
+        COMPLETED,      // 방문완료
+        NOT_VISITED,    // 취소/노쇼
+        ;
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/app/waiting/AppWaitingReservationResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/app/waiting/AppWaitingReservationResponse.java
@@ -1,0 +1,76 @@
+package im.fooding.app.dto.response.app.waiting;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.StoreWaitingChannel;
+import im.fooding.core.model.waiting.StoreWaitingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+@Value
+@Builder(access = AccessLevel.PRIVATE)
+public class AppWaitingReservationResponse {
+
+    @Schema(description = "ID", requiredMode = RequiredMode.REQUIRED, example = "ID")
+    long id;
+
+    @Schema(description = "예약 type (RESERVATION, ON_SITE_WAITING, ONLINE_WAITING)", requiredMode = RequiredMode.REQUIRED, example = "RESERVATION")
+    ReservationType type;
+
+    @Schema(description = "가게 이름", requiredMode = RequiredMode.REQUIRED, example = "바다풍경 정육식당 흑돼지 용담탑동본점")
+    String storeName;
+
+    @Schema(description = "방문 상태 (SCHEDULED, COMPLETED, NOT_VISITED)", requiredMode = RequiredMode.REQUIRED, example = "SCHEDULED")
+    VisitStatus visitStatus;
+
+    @Schema(description = "예약 일시 (예약시 존재)", requiredMode = RequiredMode.NOT_REQUIRED, example = "2025-04-30T15:30:00")
+    LocalDateTime reservationTime;
+
+    @Schema(description = "예약 인원 수", requiredMode = RequiredMode.REQUIRED, example = "3")
+    int numberOfPeople;
+
+    @RequiredArgsConstructor
+    public enum VisitStatus {
+        SCHEDULED,      // 방문예정
+        COMPLETED,      // 방문완료
+        NOT_VISITED,    // 취소/노쇼
+        ;
+    }
+
+    @RequiredArgsConstructor
+    public enum ReservationType {
+        RESERVATION,        // 예약
+        ON_SITE_WAITING,    // 현장 웨이팅
+        ONLINE_WAITING,     // 온라인 웨이팅
+        ;
+    }
+
+    public static AppWaitingReservationResponse from(StoreWaiting storeWaiting) {
+        ReservationType type = storeWaiting.getChannel() == StoreWaitingChannel.ONLINE
+                ? ReservationType.ONLINE_WAITING
+                : ReservationType.ON_SITE_WAITING;
+        VisitStatus visitStatus = toVisitStatus(storeWaiting.getStatus());
+        int numberOfPeople = storeWaiting.getAdultCount() + storeWaiting.getInfantCount();
+
+        return AppWaitingReservationResponse.builder()
+                .id(storeWaiting.getId())
+                .type(type)
+                .storeName(storeWaiting.getStoreName())
+                .visitStatus(visitStatus)
+                .numberOfPeople(numberOfPeople)
+                .build();
+    }
+
+    private static VisitStatus toVisitStatus(StoreWaitingStatus storeWaitingStatus) {
+        return switch (storeWaitingStatus) {
+            case WAITING ->  VisitStatus.SCHEDULED;
+            case SEATED -> VisitStatus.COMPLETED;
+            case CANCELLED -> VisitStatus.NOT_VISITED;
+        };
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- [USER 추상화된 웨이팅 리스트 조회 API 추가](https://www.notion.so/benkang/USER-API-22f83feabad3804c8371f6353c28933a?source=copy_link)

## 변경사항
- USER 추상화된 웨이팅 리스트 조회 API 추가