### PR TITLE
[BE-242] [BE-244] [BE-252] 엘라스틱서치 구성과 스토어 검색을 엘라스틱 서치 버전 추가

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -56,6 +56,9 @@ jobs:
             STORAGE_API_TOKEN=${{ secrets.STAGE_STORAGE_API_TOKEN  }}
             STORAGE_API_BUCKET_ID=${{ secrets.STAGE_STORAGE_API_BUCKET_ID  }}
             JPA_DDL_AUTO=${{ secrets.STAGE_JPA_DDL_AUTO  }}
+            ELASTIC_SEARCH_URIS=${{ secrets.STAGE_ELASTIC_SEARCH_URIS}}
+            ELASTIC_SEARCH_USERNAME=${{ secrets.STAGE_ELASTIC_SEARCH_USERNAME }}
+            ELASTIC_SEARCH_PASSWORD=${{ secrets.STAGE_ELASTIC_SEARCH_PASSWORD }}
       - name: Deployment
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,9 @@ jobs:
             STORAGE_API_TOKEN=${{ secrets.STORAGE_API_TOKEN  }}
             STORAGE_API_BUCKET_ID=${{ secrets.STORAGE_API_BUCKET_ID  }}
             JPA_DDL_AUTO=${{ secrets.JPA_DDL_AUTO  }}
+            ELASTIC_SEARCH_URIS=${{ secrets.ELASTIC_SEARCH_URIS}}
+            ELASTIC_SEARCH_USERNAME=${{ secrets.ELASTIC_SEARCH_USERNAME }}
+            ELASTIC_SEARCH_PASSWORD=${{ secrets.ELASTIC_SEARCH_PASSWORD }}
       - name: Deployment
         uses: appleboy/ssh-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.env
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # fooding-backend
 
+## 🔧 처음 실행 가이드
+ 
+- **도커 컨테이너 셋업 및 실행**
+```bash
+   chmod +x setup.sh
+   ./setup.sh
 ```
-1. 도커실행
-2. 터미널에 docker compose up -d && database 확인
-3. application start
-```
+
+- **접속 확인**
+- **application 실행**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,38 @@ services:
       - TZ=Asia/Seoul
     volumes:
       - ./mysql/init:/docker-entrypoint-initdb.d
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=false
+      - ELASTIC_PASSWORD=1234   # elastic 유저 기본 비밀번호
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ports:
+      - 9200:9200
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - elk
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.4
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_SERVICEACCOUNTTOKEN=${ELASTICSEARCH_SERVICE_ACCOUNT_TOKEN}
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch
+    networks:
+      - elk
+
+volumes:
+  esdata: {}
+
+networks:
+  elk: {}

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStoreController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/store/UserStoreController.java
@@ -33,6 +33,12 @@ public class UserStoreController {
         return ApiResult.ok(service.list(request, userInfo));
     }
 
+    @GetMapping("/elastic-search")
+    @Operation(summary = "가게 목록 조회")
+    public ApiResult<PageResponse<UserStoreListResponse>> list_v2(@Valid UserSearchStoreRequest request, @AuthenticationPrincipal UserInfo userInfo) {
+        return ApiResult.ok(service.list_v2(request, userInfo));
+    }
+
     @GetMapping("/{id}")
     @Operation(summary = "가게 단건조회")
     public ApiResult<UserStoreResponse> retrieve(@PathVariable Long id, @AuthenticationPrincipal UserInfo userInfo) {

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
@@ -9,12 +9,14 @@ import im.fooding.core.common.PageResponse;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StorePosition;
+import im.fooding.core.model.store.document.StoreDocument;
 import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.Role;
 import im.fooding.core.model.user.User;
 import im.fooding.core.service.region.RegionService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
+import im.fooding.core.service.store.document.StoreDocumentService;
 import im.fooding.core.service.store.subway.SubwayStationService;
 import im.fooding.core.service.user.UserAuthorityService;
 import im.fooding.core.service.user.UserService;
@@ -37,6 +39,7 @@ public class AdminStoreService {
     private final UserAuthorityService userAuthorityService;
     private final RegionService regionService;
     private final SubwayStationService subwayStationService;
+    private final StoreDocumentService storeDocumentService;
 
     @Transactional(readOnly = true)
     public PageResponse<AdminStoreResponse> list(AdminSearchStoreRequest request) {
@@ -67,6 +70,8 @@ public class AdminStoreService {
 
         storeMemberService.create(store, user, StorePosition.OWNER);
 
+        storeDocumentService.save(StoreDocument.from(store));
+
         return store.getId();
     }
 
@@ -74,15 +79,18 @@ public class AdminStoreService {
     public void update(Long id, AdminUpdateStoreRequest request) {
         Region region = regionService.get(request.getRegionId());
 
-        List<SubwayStation> nearStations = subwayStationService.getNearStations( request.getLatitude(), request.getLongitude() );
+        List<SubwayStation> nearStations = subwayStationService.getNearStations(request.getLatitude(), request.getLongitude());
 
-        storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
+        Store store = storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
                 request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
                 request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude(), nearStations);
+
+        storeDocumentService.save(StoreDocument.from(store));
     }
 
     @Transactional
     public void delete(Long id, Long deletedBy) {
         storeService.delete(id, deletedBy);
+        storeDocumentService.delete(String.valueOf(id));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
@@ -7,11 +7,13 @@ import im.fooding.app.dto.response.ceo.store.CeoStoreResponse;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StorePosition;
+import im.fooding.core.model.store.document.StoreDocument;
 import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.User;
 import im.fooding.core.service.region.RegionService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
+import im.fooding.core.service.store.document.StoreDocumentService;
 import im.fooding.core.service.store.subway.SubwayStationService;
 import im.fooding.core.service.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -31,6 +32,7 @@ public class CeoStoreService {
     private final UserService userService;
     private final RegionService regionService;
     private final SubwayStationService subwayStationService;
+    private final StoreDocumentService storeDocumentService;
 
     @Transactional(readOnly = true)
     public List<CeoStoreResponse> list(long userId, CeoSearchStoreRequest search) {
@@ -54,6 +56,9 @@ public class CeoStoreService {
 
         storeMemberService.create(store, user, StorePosition.OWNER);
 
+        // elasticSearch document 생성
+        storeDocumentService.save(StoreDocument.from(store));
+
         return store.getId();
     }
 
@@ -63,15 +68,20 @@ public class CeoStoreService {
         Region region = regionService.get(request.getRegionId());
 
         // 주소를 통해 인근 지하철역 조회 ( 1km 반경 내 )
-        List<SubwayStation> nearStations = subwayStationService.getNearStations( request.getLatitude(), request.getLongitude() );
+        List<SubwayStation> nearStations = subwayStationService.getNearStations(request.getLatitude(), request.getLongitude());
 
-        storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
+        Store store = storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
                 request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
                 request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude(), nearStations);
+
+        // elasticSearch document 수정
+        storeDocumentService.save(StoreDocument.from(store));
     }
+
     @Transactional
     public void delete(Long id, long deletedBy) {
         storeMemberService.checkMember(id, deletedBy);
         storeService.delete(id, deletedBy);
+        storeDocumentService.delete(String.valueOf(id));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStoreService.java
@@ -10,6 +10,7 @@ import im.fooding.core.global.UserInfo;
 import im.fooding.core.global.util.Util;
 import im.fooding.core.model.bookmark.Bookmark;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.document.StoreDocument;
 import im.fooding.core.model.store.information.StoreDailyOperatingTime;
 import im.fooding.core.model.store.information.StoreOperatingHour;
 import im.fooding.core.model.waiting.Waiting;
@@ -18,9 +19,11 @@ import im.fooding.core.model.waiting.WaitingStatus;
 import im.fooding.core.service.bookmark.BookmarkService;
 import im.fooding.core.service.store.StoreOperatingHourService;
 import im.fooding.core.service.store.StoreService;
+import im.fooding.core.service.store.document.StoreDocumentService;
 import im.fooding.core.service.waiting.WaitingService;
 import im.fooding.core.service.waiting.WaitingSettingService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,24 +36,49 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserStoreService {
     private final StoreService storeService;
     private final StoreOperatingHourService storeOperatingHourService;
     private final WaitingSettingService waitingSettingService;
     private final WaitingService waitingService;
     private final BookmarkService bookmarkService;
+    private final StoreDocumentService storeDocumentService;
 
     @Transactional(readOnly = true)
     public PageResponse<UserStoreListResponse> list(UserSearchStoreRequest request, UserInfo userInfo) {
         Page<Store> stores = storeService.list(request.getPageable(), request.getSortType(), request.getSortDirection(), false);
         List<UserStoreListResponse> list = stores.getContent().stream().map(store -> UserStoreListResponse.of(store, null)).toList();
 
-        // 영업상태 세팅
-        setOperatingStatus(list);
+        if (list != null && !list.isEmpty()) {
+            // 영업상태 세팅
+            setOperatingStatus(list);
 
-        // 북마크 여부 세팅
-        if (userInfo != null) {
-            setBookmarked(list, userInfo.getId());
+            // 북마크 여부 세팅
+            if (userInfo != null) {
+                setBookmarked(list, userInfo.getId());
+            }
+        }
+        return PageResponse.of(list, PageInfo.of(stores));
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<UserStoreListResponse> list_v2(UserSearchStoreRequest request, UserInfo userInfo) {
+        Page<StoreDocument> stores = storeDocumentService.fullTextSearch(request.getSearchString(), request.getSortType(), request.getSortDirection(), request.getPageable());
+        List<Long> ids = stores.getContent().stream().map(StoreDocument::getId).toList();
+
+        List<UserStoreListResponse> list = storeService.list(ids).stream()
+                .map(store -> UserStoreListResponse.of(store, null))
+                .toList();
+
+        if (list != null && !list.isEmpty()) {
+            // 영업상태 세팅
+            setOperatingStatus(list);
+
+            // 북마크 여부 세팅
+            if (userInfo != null) {
+                setBookmarked(list, userInfo.getId());
+            }
         }
 
         return PageResponse.of(list, PageInfo.of(stores));
@@ -135,7 +163,6 @@ public class UserStoreService {
     }
 
     private void setBookmarked(List<UserStoreListResponse> list, Long userId) {
-        if (userId == null) return;
         List<Bookmark> userBookmarks = bookmarkService.findAllByUserId(userId);
         Set<Long> bookmarkedStoreIds = userBookmarks.stream().map(bookmark -> bookmark.getStore().getId()).collect(Collectors.toSet());
         list.forEach(response -> response.setBookmarked(bookmarkedStoreIds.contains(response.getId())));

--- a/fooding-api/src/main/resources/application-local.yml
+++ b/fooding-api/src/main/resources/application-local.yml
@@ -7,6 +7,11 @@ spring:
     resources:
       add-mappings: false
 
+  elasticsearch:
+    uris: http://localhost:9200
+    username: elastic
+    password: 1234
+
   datasource:
     url: jdbc:mysql://localhost:3308/fooding?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
     username: root

--- a/fooding-api/src/main/resources/application-prod.yml
+++ b/fooding-api/src/main/resources/application-prod.yml
@@ -7,6 +7,11 @@ spring:
     resources:
       add-mappings: false
 
+  elasticsearch:
+    uris: ${ELASTIC_SEARCH_URIS}
+    username: ${ELASTIC_SEARCH_USERNAME}
+    password: ${ELASTIC_SEARCH_PASSWORD}
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USER:fooding}

--- a/fooding-api/src/main/resources/application-stage.yml
+++ b/fooding-api/src/main/resources/application-stage.yml
@@ -7,6 +7,11 @@ spring:
     resources:
       add-mappings: false
 
+  elasticsearch:
+    uris: ${ELASTIC_SEARCH_URIS}
+    username: ${ELASTIC_SEARCH_USERNAME}
+    password: ${ELASTIC_SEARCH_PASSWORD}
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USER:fooding}

--- a/fooding-core/build.gradle.kts
+++ b/fooding-core/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.3"))
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
+    //elasticsearch
+    implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
+    implementation("co.elastic.clients:elasticsearch-java:8.13.4")
+
     //querydsl
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
     annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")

--- a/fooding-core/src/main/java/im/fooding/core/FoodingCoreConfiguration.java
+++ b/fooding-core/src/main/java/im/fooding/core/FoodingCoreConfiguration.java
@@ -3,6 +3,7 @@ package im.fooding.core;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
@@ -11,5 +12,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableAutoConfiguration
 @EnableAsync
 @EnableFeignClients
+@EnableElasticsearchRepositories(basePackages = "im.fooding.core.repository.elasticsearch")
 public class FoodingCoreConfiguration {
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/ElasticsearchAutoConfig.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/ElasticsearchAutoConfig.java
@@ -1,0 +1,23 @@
+package im.fooding.core.global.elasticsearch;
+
+import im.fooding.core.global.elasticsearch.setup.StoreIndexSetup;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchAutoConfig {
+    private final StoreIndexSetup storeIndexSetup;
+
+    public ElasticsearchAutoConfig(StoreIndexSetup storeIndexSetup) {
+        this.storeIndexSetup = storeIndexSetup;
+    }
+
+    @Bean
+    public ApplicationRunner initializeIndices() {
+        return args -> {
+            storeIndexSetup.createStoreIndex();
+            // 다른 인덱스도 여기서 생성 가능
+        };
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/ElasticsearchIndexInitializer.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/ElasticsearchIndexInitializer.java
@@ -1,0 +1,7 @@
+package im.fooding.core.global.elasticsearch;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+
+public interface ElasticsearchIndexInitializer {
+    <T> void createIndexIfNotExists(Class<T> documentClass, IndexSettingMapping settingMapping, ElasticsearchOperations operations);
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/ElasticsearchIndexInitializerImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/ElasticsearchIndexInitializerImpl.java
@@ -1,0 +1,22 @@
+package im.fooding.core.global.elasticsearch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ElasticsearchIndexInitializerImpl implements ElasticsearchIndexInitializer {
+
+    @Override
+    public <T> void createIndexIfNotExists(Class<T> documentClass, IndexSettingMapping settingMapping, ElasticsearchOperations operations) {
+        IndexOperations indexOps = operations.indexOps(documentClass);
+        if (!indexOps.exists()) {
+            indexOps.create(settingMapping.getSettings());
+            indexOps.putMapping(Document.from(settingMapping.getMappings()));
+            log.info("new elasticsearch index created : {} ", indexOps.getSettings());
+        }
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/IndexSettingMapping.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/IndexSettingMapping.java
@@ -1,0 +1,21 @@
+package im.fooding.core.global.elasticsearch;
+
+import java.util.Map;
+
+public class IndexSettingMapping {
+    private final Map<String, Object> settings;
+    private final Map<String, Object> mappings;
+
+    public IndexSettingMapping(Map<String, Object> settings, Map<String, Object> mappings) {
+        this.settings = settings;
+        this.mappings = mappings;
+    }
+
+    public Map<String, Object> getSettings() {
+        return settings;
+    }
+
+    public Map<String, Object> getMappings() {
+        return mappings;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/setup/StoreIndexSetup.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/elasticsearch/setup/StoreIndexSetup.java
@@ -1,0 +1,70 @@
+package im.fooding.core.global.elasticsearch.setup;
+
+import im.fooding.core.global.elasticsearch.ElasticsearchIndexInitializer;
+import im.fooding.core.global.elasticsearch.IndexSettingMapping;
+import im.fooding.core.model.store.document.StoreDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class StoreIndexSetup {
+    private final ElasticsearchIndexInitializer initializer;
+    private final ElasticsearchOperations operations;
+
+    public void createStoreIndex() {
+        Map<String, Object> settings = Map.of(
+                "index", Map.of(
+                        "number_of_shards", 1,
+                        "number_of_replicas", 0,
+                        "analysis", Map.of(
+                                "filter", Map.of(
+                                        "edge_ngram_filter", Map.of(
+                                                "type", "edge_ngram",
+                                                "min_gram", 1,
+                                                "max_gram", 20
+                                        )
+                                ),
+                                "analyzer", Map.of(
+                                        "autocomplete_index_analyzer", Map.of(
+                                                "type", "custom",
+                                                "tokenizer", "whitespace",
+                                                "filter", List.of("lowercase", "edge_ngram_filter")
+                                        ),
+                                        "autocomplete_search_analyzer", Map.of(
+                                                "type", "custom",
+                                                "tokenizer", "whitespace",
+                                                "filter", List.of("lowercase")
+                                        )
+                                )
+                        )
+                )
+        );
+
+        Map<String, Object> mappings = Map.of(
+                "properties", Map.of(
+                        "id", Map.of("type", "long"),
+                        "name", Map.of(
+                                "type", "text",
+                                "analyzer", "autocomplete_index_analyzer",
+                                "search_analyzer", "autocomplete_search_analyzer"
+                        ),
+                        "category", Map.of("type", "keyword"),
+                        "address", Map.of("type", "text"),
+                        "reviewCount", Map.of("type", "integer"),
+                        "averageRating", Map.of("type", "double"),
+                        "visitCount", Map.of("type", "integer"),
+                        "createdAt", Map.of(
+                                "type", "date",
+                                "format", "yyyy-MM-dd'T'HH:mm:ss.SSS||epoch_millis"
+                        )
+                )
+        );
+
+        initializer.createIndexIfNotExists(StoreDocument.class, new IndexSettingMapping(settings, mappings), operations);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/document/StoreDocument.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/document/StoreDocument.java
@@ -1,0 +1,66 @@
+package im.fooding.core.model.store.document;
+
+import im.fooding.core.model.store.Store;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Document(indexName = "stores_v1", createIndex = false)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreDocument {
+    @Id
+    @Field(type = FieldType.Long)
+    private Long id;
+
+    @Field(type = FieldType.Text)
+    private String name;
+
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    @Field(type = FieldType.Text)
+    private String address;
+
+    @Field(type = FieldType.Integer)
+    private int reviewCount;
+
+    @Field(type = FieldType.Double)
+    private double averageRating;
+
+    @Field(type = FieldType.Integer)
+    private int visitCount;
+
+    @Field(type = FieldType.Date, format = {DateFormat.date_hour_minute_second_millis, DateFormat.epoch_millis})
+    private LocalDateTime createdAt;
+
+    @Builder
+    public StoreDocument(Long id, String name, String category, String address, int reviewCount, double averageRating, int visitCount, LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.address = address;
+        this.reviewCount = reviewCount;
+        this.averageRating = averageRating;
+        this.visitCount = visitCount;
+        this.createdAt = createdAt;
+    }
+
+    public static StoreDocument from(Store store) {
+        return StoreDocument.builder()
+                .id(store.getId())
+                .name(store.getName())
+                .category(store.getCategory())
+                .address(store.getAddress())
+                .reviewCount(store.getReviewCount())
+                .averageRating(store.getAverageRating())
+                .visitCount(store.getVisitCount())
+                .createdAt(store.getCreatedAt())
+                .build();
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/elasticsearch/store/StoreDocumentRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/elasticsearch/store/StoreDocumentRepository.java
@@ -1,0 +1,7 @@
+package im.fooding.core.repository.elasticsearch.store;
+
+import im.fooding.core.model.store.document.StoreDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface StoreDocumentRepository extends ElasticsearchRepository<StoreDocument,String> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepository.java
@@ -22,4 +22,6 @@ public interface QStoreRepository {
     List<Store> listByUserId(long userId, StoreFilter filter);
 
     Optional<Store> retrieve(long storeId);
+
+    List<Store> list(List<Long> ids);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -36,6 +36,10 @@ public class StoreService {
         return storeRepository.list(pageable, sortType, sortDirection, includeDeleted);
     }
 
+    public List<Store> list(List<Long> ids) {
+        return storeRepository.list(ids);
+    }
+
     /**
      * userId로 가게 목록 조회
      *
@@ -112,7 +116,7 @@ public class StoreService {
         return storeRepository.save(store);
     }
 
-    public void update(
+    public Store update(
             long id,
             String name,
             Region region,
@@ -136,6 +140,7 @@ public class StoreService {
         store.update(name, region, city, address, category, description, contactNumber, priceCategory, eventDescription,
                 direction, information, isParkingAvailable, isNewOpen, isTakeOut, latitude, longitude);
         store.setNearSubwayStations( stations );
+        return store;
     }
 
     public void delete(long id, Long deletedBy) {

--- a/fooding-core/src/main/java/im/fooding/core/service/store/document/StoreDocumentService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/document/StoreDocumentService.java
@@ -1,0 +1,78 @@
+package im.fooding.core.service.store.document;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import im.fooding.core.model.store.StoreSortType;
+import im.fooding.core.model.store.document.StoreDocument;
+import im.fooding.core.repository.elasticsearch.store.StoreDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.query.SortDirection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreDocumentService {
+    private final StoreDocumentRepository repository;
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    public void save(StoreDocument storeDocument) {
+        repository.save(storeDocument);
+    }
+
+    public void delete(String id) {
+        repository.deleteById(id);
+    }
+
+    public Page<StoreDocument> fullTextSearch(String searchString, StoreSortType sortType, SortDirection direction, Pageable pageable) {
+        SortOrder sortOrder = (direction == SortDirection.ASCENDING) ? SortOrder.Asc : SortOrder.Desc;
+        String field = switch (sortType) {
+            case REVIEW -> "reviewCount";
+            case RECENT -> "createdAt";
+            case AVERAGE_RATING -> "averageRating";
+            case VISIT -> "visitCount";
+        };
+
+        Query query;
+
+        if (!StringUtils.hasText(searchString)) {
+            query = MatchAllQuery.of(m -> m)._toQuery();
+        } else {
+            query = MultiMatchQuery.of(m -> m
+                    .fields("name")
+                    .query(searchString)
+                    .operator(Operator.And)
+            )._toQuery();
+        }
+
+        NativeQuery nativeQuery = NativeQuery.builder()
+                .withQuery(query)
+                .withSort(s -> s
+                        .field(f -> f
+                                .field(field)
+                                .order(sortOrder)
+                        )
+                )
+                .withPageable(pageable)
+                .build();
+
+        SearchHits<StoreDocument> searchHits = elasticsearchOperations.search(nativeQuery, StoreDocument.class);
+        List<StoreDocument> content = searchHits.get().map(SearchHit::getContent).toList();
+
+        return new PageImpl<>(content, pageable, searchHits.getTotalHits());
+    }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+echo ""
+echo "📦 Docker Compose로 Elasticsearch, Kibana, MySQL 환경을 구성합니다."
+
+echo ""
+echo "Step 1: mysql 컨테이너 시작"
+docker-compose up -d mysql
+
+echo ""
+echo "Step 2: Elasticsearch 컨테이너 시작"
+docker-compose up -d elasticsearch
+
+echo ""
+echo "Elasticsearch가 준비될 때까지 대기..."
+until curl -s http://localhost:9200 >/dev/null; do
+  sleep 1
+done
+
+echo ""
+echo "Elasticsearch 준비 완료"
+
+echo ""
+echo "STEP 3: Kibana 서비스 토큰 생성 중..."
+TOKEN=$(docker exec elasticsearch bin/elasticsearch-service-tokens create elastic/kibana kibana-token | awk -F' = ' '{print $2}')
+
+if [[ -z "$TOKEN" ]]; then
+  echo "토큰 생성 실패. 수동으로 생성하세요."
+  exit 1
+fi
+
+# .env에 저장
+if [ ! -f .env ]; then
+  echo "ELASTICSEARCH_SERVICE_ACCOUNT_TOKEN=$TOKEN" > .env
+  echo ".env 파일이 생성되었습니다."
+else
+  echo "기존 토큰을 업데이트합니다."
+  sed -i.bak "s|^ELASTICSEARCH_SERVICE_ACCOUNT_TOKEN=.*|ELASTICSEARCH_SERVICE_ACCOUNT_TOKEN=$TOKEN|" .env
+fi
+
+echo ""
+echo "STEP 4: Kibana 컨테이너 시작"
+docker-compose up -d kibana
+
+echo ""
+echo "완료"


### PR DESCRIPTION
## 이슈
[BE-242](https://www.notion.so/benkang/docker-compose-Elastic-Search-23283feabad380888b75f185403c80a4?source=copy_link)
[BE-244](https://www.notion.so/benkang/Elastic-Search-23283feabad3802ebf70e3823e310676?source=copy_link)
[BE-252](https://www.notion.so/benkang/ES-23b83feabad380e8b6e5d94d861ab930?source=copy_link)

## 내용
- 스프링 부트 application 실행시 없는 인덱스 자동 생성되는 config 추가
- kibana docker 올릴 때 토큰이 필요하여 setup.sh로 토큰 받아서 설치하도록 추가
- 기존 스토어는 유지하고 엘라스틱 버전 테스트용 list api 추가
- 인프라 세팅이 되어야 스테이지 실행될 것 같아서 develop에는 올리지 않았습니다.