### PR TITLE
[BE-256] [BE-262] [BE-263] [BE-264] 웨이팅 추상화 목록에 MongoDB 적용 및 프론트 요청 반영

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/waiting/UserStoreWaitingController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/waiting/UserStoreWaitingController.java
@@ -1,0 +1,27 @@
+package im.fooding.app.controller.user.waiting;
+
+import im.fooding.app.dto.response.user.waiting.UserStoreWaitingResponse;
+import im.fooding.app.service.user.waiting.UserStoreWaitingService;
+import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/store-waitings")
+@Tag(name = "UserStoreWaitingController", description = "유저 스토어 웨이팅 컨트롤러")
+public class UserStoreWaitingController {
+
+    private final UserStoreWaitingService userWaitingService;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "스토어 웨이팅 조회")
+    public ApiResult<UserStoreWaitingResponse> getStoreWaiting(@PathVariable long id) {
+        return ApiResult.ok(userWaitingService.getStoreWaiting(id));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/plan/UserPlanResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/plan/UserPlanResponse.java
@@ -1,75 +1,57 @@
 package im.fooding.app.dto.response.user.plan;
 
-import im.fooding.core.model.waiting.StoreWaiting;
-import im.fooding.core.model.waiting.StoreWaitingChannel;
-import im.fooding.core.model.waiting.StoreWaitingStatus;
+import im.fooding.core.model.plan.Plan;
+import im.fooding.core.model.plan.Plan.ReservationType;
+import im.fooding.core.model.plan.Plan.VisitStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 @Value
 @Builder(access = AccessLevel.PRIVATE)
 public class UserPlanResponse {
 
-    @Schema(description = "ID", requiredMode = RequiredMode.REQUIRED, example = "ID")
-    long id;
+    @Schema(description = "ID", requiredMode = RequiredMode.REQUIRED, example = "6889bf12db34d469470f868e")
+    String id;
 
-    @Schema(description = "예약 type (RESERVATION, ON_SITE_WAITING, ONLINE_WAITING)", requiredMode = RequiredMode.REQUIRED, example = "RESERVATION")
-    ReservationType type;
+    @Schema(description = "예약 type (RESERVATION, ONSITE_WAITING, ONLINE_WAITING)", requiredMode = RequiredMode.REQUIRED, example = "RESERVATION")
+    ReservationType reservationType;
+
+    @Schema(description = "예약/웨이팅 도메인의 ID", requiredMode = RequiredMode.REQUIRED, example = "1")
+    long originId;
 
     @Schema(description = "가게 이름", requiredMode = RequiredMode.REQUIRED, example = "바다풍경 정육식당 흑돼지 용담탑동본점")
-    String storeName;
+    long storeId;
 
     @Schema(description = "방문 상태 (SCHEDULED, COMPLETED, NOT_VISITED)", requiredMode = RequiredMode.REQUIRED, example = "SCHEDULED")
     VisitStatus visitStatus;
 
-    @Schema(description = "예약 일시 (예약시 존재)", requiredMode = RequiredMode.NOT_REQUIRED, example = "2025-04-30T15:30:00")
+    @Schema(description = "예약 일시", requiredMode = RequiredMode.REQUIRED, example = "2025-07-30T06:01:16.711Z")
     LocalDateTime reservationTime;
 
-    @Schema(description = "예약 인원 수", requiredMode = RequiredMode.REQUIRED, example = "3")
-    int numberOfPeople;
+    @Schema(description = "예약한 유아용 의자 수", requiredMode = RequiredMode.REQUIRED, example = "3")
+    int infantChairCount;
 
-    @RequiredArgsConstructor
-    public enum VisitStatus {
-        SCHEDULED,      // 방문예정
-        COMPLETED,      // 방문완료
-        NOT_VISITED,    // 취소/노쇼
-        ;
-    }
+    @Schema(description = "예약한 유아 수", requiredMode = RequiredMode.REQUIRED, example = "3")
+    int infantCount;
 
-    @RequiredArgsConstructor
-    public enum ReservationType {
-        RESERVATION,        // 예약
-        ON_SITE_WAITING,    // 현장 웨이팅
-        ONLINE_WAITING,     // 온라인 웨이팅
-        ;
-    }
+    @Schema(description = "예약한 성인 수", requiredMode = RequiredMode.REQUIRED, example = "3")
+    int adultCount;
 
-    public static UserPlanResponse from(StoreWaiting storeWaiting) {
-        ReservationType type = storeWaiting.getChannel() == StoreWaitingChannel.ONLINE
-                ? ReservationType.ONLINE_WAITING
-                : ReservationType.ON_SITE_WAITING;
-        VisitStatus visitStatus = toVisitStatus(storeWaiting.getStatus());
-        int numberOfPeople = storeWaiting.getAdultCount() + storeWaiting.getInfantCount();
-
-        return UserPlanResponse.builder()
-                .id(storeWaiting.getId())
-                .type(type)
-                .storeName(storeWaiting.getStoreName())
-                .visitStatus(visitStatus)
-                .numberOfPeople(numberOfPeople)
-                .build();
-    }
-
-    private static VisitStatus toVisitStatus(StoreWaitingStatus storeWaitingStatus) {
-        return switch (storeWaitingStatus) {
-            case WAITING ->  VisitStatus.SCHEDULED;
-            case SEATED -> VisitStatus.COMPLETED;
-            case CANCELLED -> VisitStatus.NOT_VISITED;
-        };
+    public static UserPlanResponse from(Plan plan) {
+        return new UserPlanResponse(
+                plan.getId().toString(),
+                plan.getReservationType(),
+                plan.getOriginId(),
+                plan.getStoreId(),
+                plan.getVisitStatus(),
+                plan.getReservationTime(),
+                plan.getInfantChairCount(),
+                plan.getInfantCount(),
+                plan.getAdultCount()
+        );
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/waiting/UserStoreWaitingResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/waiting/UserStoreWaitingResponse.java
@@ -1,0 +1,54 @@
+package im.fooding.app.dto.response.user.waiting;
+
+import im.fooding.core.model.waiting.StoreWaiting;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+@Value
+public class UserStoreWaitingResponse {
+
+    @Schema(description = "유저 id", example = "1")
+    Long userId;
+
+    @Schema(description = "웨이팅 유저 id", example = "1")
+    Long waitingUserId;
+
+    @Schema(description = "가게 id", example = "1")
+    Long storeId;
+
+    @Schema(description = "등록 방법(IN_PERSON, ONLINE)", example = "IN_PERSON")
+    String channel;
+
+    @Schema(description = "유아용 의자 개수", example = "1")
+    Integer infantChairCount;
+
+    @Schema(description = "유아 수", example = "1")
+    Integer infantCount;
+
+    @Schema(description = "성인 수", example = "1")
+    Integer adultCount;
+
+    @Schema(description = "메모", example = "메모 내용입니다.")
+    String memo;
+
+    public static UserStoreWaitingResponse from(StoreWaiting waiting) {
+        Long userId = null;
+        if (waiting.getUser() != null) {
+            userId = waiting.getUser().getId();
+        }
+        Long waitingUserId = null;
+        if (waiting.getWaitingUser() != null) {
+            waitingUserId = waiting.getWaitingUser().getId();
+        }
+        return new UserStoreWaitingResponse(
+                userId,
+                waitingUserId,
+                waiting.getStoreId(),
+                waiting.getChannel().name(),
+                waiting.getInfantChairCount(),
+                waiting.getInfantCount(),
+                waiting.getAdultCount(),
+                waiting.getMemo()
+        );
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/plan/UserPlanService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/plan/UserPlanService.java
@@ -4,62 +4,22 @@ import im.fooding.app.dto.request.user.plan.UserPlanRetrieveRequest;
 import im.fooding.app.dto.response.user.plan.UserPlanResponse;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
-import im.fooding.core.model.waiting.StoreWaiting;
-import im.fooding.core.service.waiting.StoreWaitingService;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import im.fooding.core.model.plan.Plan;
+import im.fooding.core.service.plan.PlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class UserPlanService {
 
-    private final StoreWaitingService storeWaitingService;
+    private final PlanService planService;
 
     public PageResponse<UserPlanResponse> list(UserPlanRetrieveRequest request, Long userId) {
-        Pageable pageable = request.getPageable();
+        Page<Plan> plans = planService.list(userId, request.getPageable());
+        Page<UserPlanResponse> planResponses = plans.map(UserPlanResponse::from);
 
-        List<Object> merged = new ArrayList<>();
-
-        Page<StoreWaiting> storeWaitings = storeWaitingService.listByUserId(userId, pageable);
-        merged.addAll(storeWaitings.getContent());
-
-        Page<UserPlanResponse> userPlanResponsePage = toUserPlanResponsePage(
-                merged, pageable
-        );
-
-        return PageResponse.of(
-                userPlanResponsePage.toList(),
-                PageInfo.of(userPlanResponsePage)
-        );
-    }
-    private Page<UserPlanResponse> toUserPlanResponsePage(
-            List<Object> merged, Pageable pageable
-    ) {
-        List<UserPlanResponse> mappedList = merged.stream()
-                .map(obj -> {
-                    if (obj instanceof StoreWaiting sw) {
-                        return UserPlanResponse.from(sw);
-                    } else {
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .toList();
-
-        // 페이징 처리
-        int start = pageable.getPageNumber() * pageable.getPageSize();
-        int end = Math.min(start + pageable.getPageSize(), mappedList.size());
-        List<UserPlanResponse> pageContent =
-                start > mappedList.size() ? Collections.emptyList() : mappedList.subList(start, end);
-         return new PageImpl<>(pageContent, pageable, mappedList.size());
+        return PageResponse.of(planResponses.toList(), PageInfo.of(planResponses));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/waiting/UserStoreWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/waiting/UserStoreWaitingService.java
@@ -1,0 +1,19 @@
+package im.fooding.app.service.user.waiting;
+
+import im.fooding.app.dto.response.user.waiting.UserStoreWaitingResponse;
+import im.fooding.core.service.waiting.StoreWaitingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserStoreWaitingService {
+
+    private final StoreWaitingService storeWaitingService;
+
+    @Transactional(readOnly = true)
+    public UserStoreWaitingResponse getStoreWaiting(long id) {
+        return UserStoreWaitingResponse.from(storeWaitingService.get(id));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/StoreWaitingRegisterRequest.java
+++ b/fooding-core/src/main/java/im/fooding/core/dto/request/waiting/StoreWaitingRegisterRequest.java
@@ -1,12 +1,14 @@
 package im.fooding.core.dto.request.waiting;
 
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.user.User;
 import im.fooding.core.model.waiting.WaitingUser;
 import lombok.Builder;
 
 @Builder
 public record StoreWaitingRegisterRequest(
         WaitingUser waitingUser,
+        User user,
         Store store,
         String channel,
         int infantChairCount,

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -115,6 +115,9 @@ public enum ErrorCode {
     POINT_SHOP_NOT_FOUND(HttpStatus.BAD_REQUEST, "11000", "등록된 포인트샵 상품이 아닙니다."),
     POINT_SHOP_ISSUE_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "11001", "포인트샵 상품을 교환 가능한 수량을 초과합니다"),
     POINT_SHOP_ISSUE_DATE_INVALID(HttpStatus.BAD_REQUEST, "11002", "포인트샵 상품을 교환 가능한 일자가 아닙니다."),
+
+    // 예약/웨이팅
+    PLAN_NOT_FOUND(HttpStatus.BAD_REQUEST, "12000", "등록된 예약/웨이팅이 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/fooding-core/src/main/java/im/fooding/core/model/BaseDocument.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/BaseDocument.java
@@ -1,0 +1,38 @@
+package im.fooding.core.model;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.Persistent;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Persistent
+public abstract class BaseDocument {
+
+    @CreatedBy
+    private Long createdBy;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedBy
+    private Long updatedBy;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private boolean deleted = false;
+
+    private Long deletedBy;
+
+    public void delete(Long deletedBy) {
+        this.deleted = true;
+        this.deletedBy = deletedBy;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/plan/Plan.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/plan/Plan.java
@@ -1,0 +1,73 @@
+package im.fooding.core.model.plan;
+
+import im.fooding.core.model.BaseDocument;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "plan")
+public class Plan extends BaseDocument {
+
+    @Id
+    private ObjectId id;
+
+    private ReservationType reservationType;
+
+    private long userId;
+
+    private long originId;
+
+    private long storeId;
+
+    VisitStatus visitStatus;
+
+    private LocalDateTime reservationTime;
+
+    private int infantChairCount;
+
+    private int infantCount;
+
+    private int adultCount;
+
+    public enum VisitStatus {
+        SCHEDULED,
+        COMPLETED,
+        NOT_VISITED
+    }
+
+    public enum ReservationType {
+        RESERVATION,
+        ONSITE_WAITING,
+        ONLINE_WAITING
+    }
+
+    @Builder
+    public Plan(
+        ReservationType reservationType,
+        long userId,
+        long originId,
+        long storeId,
+        VisitStatus visitStatus,
+        LocalDateTime reservationTime,
+        int infantChairCount,
+        int infantCount,
+        int adultCount
+    ) {
+        this.reservationType = reservationType;
+        this.userId = userId;
+        this.originId = originId;
+        this.storeId = storeId;
+        this.visitStatus = visitStatus;
+        this.reservationTime = reservationTime;
+        this.infantChairCount = infantChairCount;
+        this.infantCount = infantCount;
+        this.adultCount = adultCount;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/waiting/StoreWaiting.java
@@ -80,6 +80,7 @@ public class StoreWaiting extends BaseEntity {
 
     @Builder
     public StoreWaiting(
+            User user,
             WaitingUser waitingUser,
             Store store,
             int callNumber,
@@ -90,6 +91,7 @@ public class StoreWaiting extends BaseEntity {
             int adultCount,
             String memo
     ) {
+        this.user = user;
         this.waitingUser = waitingUser;
         this.store = store;
         this.callNumber = callNumber;

--- a/fooding-core/src/main/java/im/fooding/core/repository/plan/PlanRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/plan/PlanRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.plan;
+
+import im.fooding.core.model.plan.Plan;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PlanRepository extends MongoRepository<Plan, ObjectId> {
+
+    Page<Plan> findAllByUserIdAndDeletedFalse(long userId, Pageable pageable);
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/plan/PlanService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/plan/PlanService.java
@@ -1,0 +1,52 @@
+package im.fooding.core.service.plan;
+
+import im.fooding.core.model.plan.Plan;
+import im.fooding.core.model.plan.Plan.ReservationType;
+import im.fooding.core.model.plan.Plan.VisitStatus;
+import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.repository.plan.PlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    @Transactional
+    public void create(StoreWaiting storeWaiting) {
+        ReservationType reservationType = switch (storeWaiting.getChannel()) {
+            case ONLINE -> ReservationType.ONLINE_WAITING;
+            case IN_PERSON -> ReservationType.ONSITE_WAITING;
+        };
+
+        VisitStatus visitStatus = switch (storeWaiting.getStatus()) {
+            case WAITING -> VisitStatus.SCHEDULED;
+            case CANCELLED -> VisitStatus.NOT_VISITED;
+            case SEATED -> VisitStatus.COMPLETED;
+        };
+
+        Plan plan = Plan.builder()
+                .reservationType(reservationType)
+                .userId(storeWaiting.getUser().getId())
+                .originId(storeWaiting.getId())
+                .storeId(storeWaiting.getStoreId())
+                .visitStatus(visitStatus)
+                .reservationTime(storeWaiting.getCreatedAt())
+                .infantChairCount(storeWaiting.getInfantChairCount())
+                .infantCount(storeWaiting.getInfantCount())
+                .adultCount(storeWaiting.getAdultCount())
+                .build();
+
+        planRepository.save(plan);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Plan> list(Long userId, Pageable pageable) {
+        return planRepository.findAllByUserIdAndDeletedFalse(userId, pageable);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/user/UserService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/user/UserService.java
@@ -8,6 +8,7 @@ import im.fooding.core.model.user.Gender;
 import im.fooding.core.model.user.Role;
 import im.fooding.core.model.user.User;
 import im.fooding.core.repository.user.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -202,5 +203,10 @@ public class UserService {
         return userRepository.findByPhoneNumber(phoneNumber)
                 .filter(it -> !it.isDeleted())
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public Optional<User> findOptionalByPhoneNumber(String phoneNumber) {
+        return userRepository.findByPhoneNumber(phoneNumber)
+                .filter(it -> !it.isDeleted());
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/waiting/StoreWaitingService.java
@@ -91,6 +91,7 @@ public class StoreWaitingService {
         int callNumber = generateCallNumber();
 
         StoreWaiting storeWaiting = StoreWaiting.builder()
+                .user(request.user())
                 .waitingUser(request.waitingUser())
                 .store(request.store())
                 .status(StoreWaitingStatus.WAITING)


### PR DESCRIPTION
## 관련 이슈
- [웨이팅 추상화 목록에 MongoDB 적용](https://www.notion.so/benkang/MongoDB-23d83feabad380e9aa90c87188b1972b?v=1ca83feabad3803eba48000c3c30e0e5&source=copy_link)
- [[POS] 스토어 웨이팅 등록시 있는 핸드폰 번호일 경우 예약/웨이팅에도 추가](https://www.notion.so/benkang/POS-24083feabad380199b5ec349a192c049?v=1ca83feabad3803eba48000c3c30e0e5&source=copy_link)
- [[USER] 가게 웨이팅 조회 API 추가](https://www.notion.so/benkang/USER-API-24083feabad380ea9f76ee517ea4d6f5?v=1ca83feabad3803eba48000c3c30e0e5&source=copy_link)
- [[USER] 예약/웨이팅 응답 변경](https://www.notion.so/benkang/USER-24083feabad3805fbfb3f13c00337c4e?v=1ca83feabad3803eba48000c3c30e0e5&source=copy_link)

## 주요 변경사항
- 웨이팅 추상화 목록에 MongoDB 적용
  - Plan 도메인, 서비스, 레포지토리 생성
  - 기존 Plan 응답 로직 MongoDB 이용하도록 변경
- 스토어 웨이팅 등록시 있는 핸드폰 번호일 경우 예약/웨이팅에도 추가
- [USER] 가게 웨이팅 조회 API 추가
  - 프론트 측 요청으로 plan 리스트 조회시 필요로 따로 생성
- 예약/웨이팅 응답 변경
  - 프론트 측 요청으로 인원 수 분리(전체 예약자 수에서 성인, 유아 등), 가게 이름에서 아이디로 변경
