### PR TITLE
[BE-288] 알림 템플릿 도메인 추가 및 생성, 조회 메서드 추가

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -91,6 +91,7 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "5000", "등록된 알림이 없습니다."),
     USER_NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "5001", "사용자 알림을 찾을 수 없습니다."),
     USER_NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "5002", "해당 알림에 접근할 권한이 없습니다."),
+    NOTIFICATION_TEMPLATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "5003", "등록된 알림 템플릿이 없습니다."),
 
     // 메뉴
     MENUCATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "6000", "등록된 메뉴 카테고리가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
@@ -1,0 +1,37 @@
+package im.fooding.core.model.notification;
+
+import im.fooding.core.model.BaseDocument;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("notification_templates")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class NotificationTemplate extends BaseDocument {
+
+    @Id
+    private ObjectId id;
+
+    private String subject;
+    private String content;
+    private Type type;
+    private String contact;
+
+    public enum Type {
+        WaitingCreatedEmail,
+        WaitingCreatedSms,
+    }
+
+    @Builder
+    public NotificationTemplate(String subject, String content, Type type, String contact) {
+        this.subject = subject;
+        this.content = content;
+        this.type = type;
+        this.contact = contact;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/notification/NotificationTemplateRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/notification/NotificationTemplateRepository.java
@@ -1,0 +1,8 @@
+package im.fooding.core.repository.notification;
+
+import im.fooding.core.model.notification.NotificationTemplate;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface NotificationTemplateRepository extends MongoRepository<NotificationTemplate, ObjectId> {
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/notification/NotificationTemplateService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/notification/NotificationTemplateService.java
@@ -1,0 +1,41 @@
+package im.fooding.core.service.notification;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.notification.NotificationTemplate;
+import im.fooding.core.model.notification.NotificationTemplate.Type;
+import im.fooding.core.repository.notification.NotificationTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationTemplateService {
+
+    private final NotificationTemplateRepository notificationTemplateRepository;
+
+    public ObjectId createNotificationTemplate(
+            String subject,
+            String content,
+            Type type,
+            String contact
+    ) {
+        NotificationTemplate newNotificationTemplate = NotificationTemplate.builder()
+                .subject(subject)
+                .content(content)
+                .type(type)
+                .contact(contact)
+                .build();
+
+        notificationTemplateRepository.save(newNotificationTemplate);
+
+        return newNotificationTemplate.getId();
+    }
+
+    public NotificationTemplate getNotificationTemplate(ObjectId id) {
+        return notificationTemplateRepository.findById(id)
+                .filter(it ->!it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND));
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/notification/NotificationTemplateService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/notification/NotificationTemplateService.java
@@ -3,7 +3,6 @@ package im.fooding.core.service.notification;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.notification.NotificationTemplate;
-import im.fooding.core.model.notification.NotificationTemplate.Type;
 import im.fooding.core.repository.notification.NotificationTemplateRepository;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
@@ -15,10 +14,39 @@ public class NotificationTemplateService {
 
     private final NotificationTemplateRepository notificationTemplateRepository;
 
+    public ObjectId createWaitingRegisterTemplate(
+            String store,
+            int totalPersonCount,
+            int order,
+            int waitingNumber,
+            NotificationTemplate.Type type,
+            String contact
+    ) {
+        String subject = "푸딩 웨이팅 등록 완료";
+        String content = """
+            안녕하세요 고객님!
+            [%s]에 웨이팅이 등록되었습니다. 입장 순서가 되면 안내 메시지를 보내드릴게요.
+
+            - 인원: %d명
+            - 순서: %d번째
+            - 웨이팅번호: %d
+
+            [주의사항]
+            - 차례가 되었을 때 현장에 없는 경우 입장이 취소될 수 있습니다.
+            """.formatted(store, totalPersonCount, order, waitingNumber);
+
+        return createNotificationTemplate(
+                subject,
+                content,
+                type,
+                contact
+        );
+    }
+
     public ObjectId createNotificationTemplate(
             String subject,
             String content,
-            Type type,
+            NotificationTemplate.Type type,
             String contact
     ) {
         NotificationTemplate newNotificationTemplate = NotificationTemplate.builder()


### PR DESCRIPTION
## 이슈 티켓
- [notification 템플릿 모델 생성 및 웨이팅 신청에 적용](https://www.notion.so/benkang/notification-25383feabad380d5808bd1ffc292c175?source=copy_link)

## 주요 변경사항
- 템플릿 모델 생성
- POS 웨이팅 등록에 템플릿 모델 생성 로직 추가