### PR TITLE
[BE-286] Reward 적립 관련 API 수정 및 제작

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/pos/reward/PosRewardController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/pos/reward/PosRewardController.java
@@ -1,9 +1,11 @@
 package im.fooding.app.controller.pos.reward;
 
-import im.fooding.app.dto.request.pos.reward.GetRewardRequest;
+import im.fooding.app.dto.request.pos.reward.GetPosRewardRequest;
+import im.fooding.app.dto.request.pos.reward.UpdateRewardLogRequest;
 import im.fooding.app.dto.response.pos.reward.GetPosRewardResponse;
 import im.fooding.app.service.pos.reward.PosRewardService;
 import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -21,18 +23,40 @@ public class PosRewardController {
 
     @GetMapping()
     @Operation( summary = "특정 스토어의 리워드 적립 조회" )
-    public ApiResult<Page<GetPosRewardResponse>> list(
-            @ModelAttribute GetRewardRequest request
+    public ApiResult<PageResponse<GetPosRewardResponse>> list(
+            @RequestBody GetPosRewardRequest request
     ){
         return ApiResult.ok( service.list( request ) );
     }
 
-    @PostMapping("/{id}/cancel")
+    @PatchMapping("/{id}/cancel")
     @Operation( summary = "특정 리워드 로그에 대한 적립 취소" )
     public ApiResult<Void> cancelReward(
-            @PathVariable Long id
-    ){
-        service.cancel( id );
+            @PathVariable Long id,
+            @RequestBody UpdateRewardLogRequest request
+            ){
+        service.cancel( id, request );
         return ApiResult.ok();
     }
+
+    @PatchMapping( "/{id}/approve" )
+    @Operation( summary = "특정 리워드 로그에 대한 적립 허용" )
+    public ApiResult<Void> approveReward(
+            @PathVariable Long id,
+            @RequestBody UpdateRewardLogRequest request
+    ){
+        service.approve( id, request );
+        return ApiResult.ok();
+    }
+
+    @PatchMapping( "/{id}/memo" )
+    @Operation( summary = "특정 리워드 로그에 메모 변경" )
+    public ApiResult<Void> updateMemo(
+            @PathVariable Long id,
+            @RequestBody String memo
+    ){
+        service.updateMemo( id, memo );
+        return ApiResult.ok();
+    }
+
 }

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/reward/UserRewardController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/reward/UserRewardController.java
@@ -12,10 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,7 +24,7 @@ public class UserRewardController {
     @GetMapping( "/log" )
     @Operation( summary = "스토어 별 보유 포인트 적립 내역 조회" )
     public ApiResult<PageResponse<GetRewardLogResponse>> getRewardLog(
-            @RequestBody GetRewardLogRequest request
+            @ModelAttribute GetRewardLogRequest request
     ){
         Page<GetRewardLogResponse> result = service.getRewardLog( request );
         return ApiResult.ok( PageResponse.of( result.stream().toList(), PageInfo.of( result ) )) ;
@@ -36,7 +33,7 @@ public class UserRewardController {
     @GetMapping("/store")
     @Operation( summary = "스토어 별 보유 포인트 조회" )
     public ApiResult<PageResponse<GetRewardPointResponse>> getRewardPoint(
-            @RequestBody GetRewardPointRequest request
+            @ModelAttribute GetRewardPointRequest request
     ){
         Page<GetRewardPointResponse> result = service.getRewardPoint( request );
         return ApiResult.ok( PageResponse.of( result.stream().toList(), PageInfo.of( result ) ) );

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/reward/UserRewardController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/reward/UserRewardController.java
@@ -1,0 +1,45 @@
+package im.fooding.app.controller.user.reward;
+
+import im.fooding.app.dto.request.user.reward.GetRewardLogRequest;
+import im.fooding.app.dto.request.user.reward.GetRewardPointRequest;
+import im.fooding.app.dto.response.user.reward.GetRewardLogResponse;
+import im.fooding.app.dto.response.user.reward.GetRewardPointResponse;
+import im.fooding.app.service.user.reward.RewardApplicationService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/reward")
+@Tag( name = "UserRewardController", description = "User들이 사용하는 리워드 관련 컨트롤러" )
+public class UserRewardController {
+    private final RewardApplicationService service;
+
+    @GetMapping( "/log" )
+    @Operation( summary = "스토어 별 보유 포인트 적립 내역 조회" )
+    public ApiResult<PageResponse<GetRewardLogResponse>> getRewardLog(
+            @RequestBody GetRewardLogRequest request
+    ){
+        Page<GetRewardLogResponse> result = service.getRewardLog( request );
+        return ApiResult.ok( PageResponse.of( result.stream().toList(), PageInfo.of( result ) )) ;
+    }
+
+    @GetMapping("/store")
+    @Operation( summary = "스토어 별 보유 포인트 조회" )
+    public ApiResult<PageResponse<GetRewardPointResponse>> getRewardPoint(
+            @RequestBody GetRewardPointRequest request
+    ){
+        Page<GetRewardPointResponse> result = service.getRewardPoint( request );
+        return ApiResult.ok( PageResponse.of( result.stream().toList(), PageInfo.of( result ) ) );
+    }
+
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/pos/reward/GetPosRewardRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/pos/reward/GetPosRewardRequest.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class GetRewardRequest extends BasicSearch {
+public class GetPosRewardRequest extends BasicSearch {
         @NotNull
         @Schema( description = "가게 ID" )
         Long storeId;

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/pos/reward/UpdateRewardLogRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/pos/reward/UpdateRewardLogRequest.java
@@ -1,0 +1,12 @@
+package im.fooding.app.dto.request.pos.reward;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UpdateRewardLogRequest {
+    @Schema( description = "메모" )
+    private String memo;
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/pos/reward/PosRewardService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/pos/reward/PosRewardService.java
@@ -36,16 +36,40 @@ public class PosRewardService {
     @Transactional
     public void cancel(Long rewardLogId, UpdateRewardLogRequest request){
         RewardLog log = logService.findById( rewardLogId );
-        log.updateStatus( RewardStatus.CANCELED );
-        log.updateMemo( request.getMemo() );
+        // 이미 취소되어 있는 경우 무시
+        if( log.getStatus() == RewardStatus.CANCELED ) return;
+
+        // 취소하는 로그 생성
+        RewardLog cancelLog = RewardLog.builder()
+                        .store( log.getStore() )
+                        .phoneNumber( log.getPhoneNumber() )
+                        .point( log.getPoint() )
+                        .status( RewardStatus.CANCELED )
+                        .type( log.getType() )
+                        .channel( log.getChannel() )
+                        .memo( request.getMemo() )
+                        .build();
+        logService.save( cancelLog );
         rewardService.usePoint(log.getPhoneNumber(), log.getStore().getId(), log.getPoint());
     }
 
     @Transactional
     public void approve( Long rewardLogId, UpdateRewardLogRequest request ){
         RewardLog log = logService.findById( rewardLogId );
-        log.updateStatus( RewardStatus.EARNED );
-        log.updateMemo( request.getMemo() );
+        // 이미 승인되어 있는 경우 무시
+        if( log.getStatus() == RewardStatus.EARNED ) return;
+        
+        // 승인하는 로그 생성
+        RewardLog approveLog = RewardLog.builder()
+                .store( log.getStore() )
+                .phoneNumber( log.getPhoneNumber() )
+                .point( log.getPoint() )
+                .status( RewardStatus.EARNED )
+                .type( log.getType() )
+                .channel( log.getChannel() )
+                .memo( request.getMemo() )
+                .build();
+        logService.save( approveLog );
         rewardService.addPoint( log.getPhoneNumber(), log.getStore().getId(), log.getPoint() );
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/service/pos/reward/PosRewardService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/pos/reward/PosRewardService.java
@@ -1,7 +1,10 @@
 package im.fooding.app.service.pos.reward;
 
-import im.fooding.app.dto.request.pos.reward.GetRewardRequest;
+import im.fooding.app.dto.request.pos.reward.GetPosRewardRequest;
+import im.fooding.app.dto.request.pos.reward.UpdateRewardLogRequest;
 import im.fooding.app.dto.response.pos.reward.GetPosRewardResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
 import im.fooding.core.model.reward.RewardLog;
 import im.fooding.core.model.reward.RewardStatus;
 import im.fooding.core.service.reward.RewardLogService;
@@ -20,19 +23,35 @@ public class PosRewardService {
     private final RewardLogService logService;
     private final RewardService rewardService;
 
-    public Page<GetPosRewardResponse> list(GetRewardRequest request){
-        return logService.list(
+    public PageResponse<GetPosRewardResponse> list(GetPosRewardRequest request){
+        Page<GetPosRewardResponse> result = logService.list(
                 request.getSearchString(),
                 request.getPageable(),
                 request.getStoreId(),
                 request.getPhoneNumber()
         ).map( GetPosRewardResponse::of );
+        return PageResponse.of( result.stream().toList(), PageInfo.of( result ) );
     }
 
     @Transactional
-    public void cancel( Long rewardLogId ){
+    public void cancel(Long rewardLogId, UpdateRewardLogRequest request){
         RewardLog log = logService.findById( rewardLogId );
         log.updateStatus( RewardStatus.CANCELED );
+        log.updateMemo( request.getMemo() );
         rewardService.usePoint(log.getPhoneNumber(), log.getStore().getId(), log.getPoint());
+    }
+
+    @Transactional
+    public void approve( Long rewardLogId, UpdateRewardLogRequest request ){
+        RewardLog log = logService.findById( rewardLogId );
+        log.updateStatus( RewardStatus.EARNED );
+        log.updateMemo( request.getMemo() );
+        rewardService.addPoint( log.getPhoneNumber(), log.getStore().getId(), log.getPoint() );
+    }
+
+    @Transactional
+    public void updateMemo( Long id, String memo ){
+        RewardLog log = logService.findById( id );
+        log.updateMemo( memo );
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/reward/RewardLog.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/reward/RewardLog.java
@@ -41,6 +41,9 @@ public class RewardLog extends BaseEntity {
     @Enumerated( EnumType.STRING )
     private RewardChannel channel;
 
+    @Column( name = "memo" )
+    private String memo;
+
     @Builder
     public RewardLog(
             Store store,
@@ -48,7 +51,8 @@ public class RewardLog extends BaseEntity {
             int point,
             RewardStatus status,
             RewardType type,
-            RewardChannel channel
+            RewardChannel channel,
+            String memo
     ){
         this.store = store;
         this.phoneNumber = phoneNumber;
@@ -56,9 +60,12 @@ public class RewardLog extends BaseEntity {
         this.status = status;
         this.type = type;
         this.channel = channel;
+        this.memo = memo;
     }
 
     public void updateStatus( RewardStatus status ){
         this.status = status;
     }
+
+    public void updateMemo( String memo ) { this.memo = memo; }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/reward/RewardPoint.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/reward/RewardPoint.java
@@ -36,6 +36,9 @@ public class RewardPoint extends BaseEntity {
     @Column(name = "point")
     private int point;
 
+    @Column(name = "memo")
+    private String memo;
+
     public void addPoint(int earnPoint) {
         this.point += earnPoint;
     }
@@ -47,11 +50,16 @@ public class RewardPoint extends BaseEntity {
         this.point -= usePoint;
     }
 
+    public void updateMemo( String memo ){
+        this.memo = memo;
+    }
+
     @Builder
-    public RewardPoint(Store store, String phoneNumber, User user, int point) {
+    public RewardPoint(Store store, String phoneNumber, User user, int point, String memo) {
         this.store = store;
         this.phoneNumber = phoneNumber;
         this.user = user;
         this.point = point;
+        this.memo = memo;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/reward/RewardStatus.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/reward/RewardStatus.java
@@ -1,5 +1,6 @@
 package im.fooding.core.model.reward;
 
 public enum RewardStatus {
-    PUBLISHED, EARNED, CANCELED, USED
+    // 적립, 취소, 사용완료
+    EARNED, CANCELED, USED
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/reward/RewardLogService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/reward/RewardLogService.java
@@ -70,6 +70,8 @@ public class RewardLogService {
         repository.save( rewardLog );
     }
 
+    public void save( RewardLog log ){repository.save( log );}
+
     /**
      * 리워드 로그 삭제
      * @param id


### PR DESCRIPTION
* 백로그 번호를 착각해서 285번과 286번의 브랜치 이름이 서로 뒤바뀌었습니다.

**<작업 내용>**
1. Pos에서 Reward 적립에 대해 상태를 변경할 수 있는 API 제작
2. Reward 및 RewardLog 도메인에 memo 필드 추가
3. Memo만 변경할 수 있는 API 제작
4. User 도메인에서 스토어 별로 Reward 적립 내역 및 Reward 누적 포인트를 확인할 수 있는 API 제작

- API 요청이 FE에서 제작 요청이 들어왔던 내용이라 stage에 먼저 merge 해두었습니다.