### PR TITLE
[BE-290] 웨이팅 신청 이벤트 Kafka로 핸들링하여 메세지, 이메일 보내도록 변경

### DIFF
--- a/fooding-core/src/main/java/im/fooding/core/event/waiting/StoreWaitingRegisteredEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/waiting/StoreWaitingRegisteredEvent.java
@@ -1,0 +1,8 @@
+package im.fooding.core.event.waiting;
+
+public record StoreWaitingRegisteredEvent(
+        long storeWaitingId,
+        Long userId,
+        Long waitingUserId
+) {
+}


### PR DESCRIPTION
## 이슈 티켓
- [웨이팅 신청 이벤트를 카프카로 핸들링해서 메시지 보내도록 수정](https://www.notion.so/benkang/25383feabad38055a4a7c0563ab25509?source=copy_link)

## 주요 변경 사항
- 웨이팅 신청 이벤트 Kafka로 핸들링
- 메세지 신청 이벤트를 통해 알림 메세지, 이메일 발송