### PR TITLE
[BE-292] [BE-294] Stroe 도메인 변경 및 db 업데이트

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
@@ -1,5 +1,6 @@
 package im.fooding.app.dto.request.admin.store;
 
+import im.fooding.core.model.store.StoreCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,52 +20,28 @@ public class AdminCreateStoreRequest {
     @Schema(description = "가게 지역 ID", example = "KR-11")
     private String regionId;
 
-    @NotBlank(message = "도시는 필수입니다.")
-    @Schema(description = "도시", example = "홍대")
-    private String city;
-
     @NotBlank(message = "주소는 필수입니다.")
     @Schema(description = "주소", example = "서울특별시 마포구")
     private String address;
 
-    @NotBlank(message = "카테고리는 필수입니다.")
-    @Schema(description = "카테고리", example = "한식")
-    private String category;
+    @Schema(description = "주소 상세", example = "마포빌딩 2층")
+    private String addressDetail;
 
-    @NotBlank(message = "설명은 필수입니다.")
-    @Schema(description = "설명", example = "설명설명")
+    @NotBlank(message = "업종은 필수입니다.")
+    @Schema(description = "업종", example = "KOREAN")
+    private StoreCategory category;
+
+    @NotBlank(message = "매장소개는 필수입니다.")
+    @Schema(description = "매장소개", example = "설명설명")
     private String description;
 
-    @NotBlank(message = "가격 카테고리는 필수입니다.")
-    @Schema(description = "가격대", example = "15000 ~ 30000")
-    private String priceCategory;
-
-    @Schema(description = "이벤트설명", example = "이벤트없음")
-    private String eventDescription;
-
-    @NotBlank(message = "연락처는 필수입니다.")
-    @Schema(description = "연락처", example = "010-0000-0000")
+    @NotBlank(message = "매장번호는 필수입니다.")
+    @Schema(description = "매장번호", example = "010-0000-0000")
     private String contactNumber;
 
-    @NotBlank(message = "찾아오는 길은 필수입니다.")
-    @Schema(description = "찾아오는 길", example = "홍대입구역 2번출구 앞")
+    @NotBlank(message = "찾아오시는 길은 필수입니다.")
+    @Schema(description = "찾아오시는 길", example = "홍대입구역 2번출구 앞")
     private String direction;
-
-    @NotBlank(message = "영업 정보는 필수입니다.")
-    @Schema(description = "영업 정보", example = "오전9시 ~ 오후9시")
-    private String information;
-
-    @NotNull(message = "주차 가능 여부는 필수입니다.")
-    @Schema(description = "주차가능여부", example = "true")
-    private Boolean isParkingAvailable;
-
-    @NotNull(message = "신규 오픈 여부는 필수입니다.")
-    @Schema(description = "신규오픈여부", example = "true")
-    private Boolean isNewOpen;
-
-    @NotNull(message = "포장 가능 여부는 필수입니다.")
-    @Schema(description = "포장가능여부", example = "true")
-    private Boolean isTakeOut;
 
     @NotNull(message = "위도 값은 필수입니다.")
     @Schema(description = "위도", example = "36.40947226931638")

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreRequest.java
@@ -5,8 +5,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class AdminCreateStoreRequest {
     @NotNull(message = "가게 점주는 필수입니다.")
     @Schema(description = "점주 id", example = "1")
@@ -16,7 +18,6 @@ public class AdminCreateStoreRequest {
     @Schema(description = "가게명", example = "홍가네")
     private String name;
 
-    @NotNull(message = "가게 지역은 필수입니다.")
     @Schema(description = "가게 지역 ID", example = "KR-11")
     private String regionId;
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
@@ -5,14 +5,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class AdminUpdateStoreRequest {
     @NotBlank(message = "가게 이름은 필수입니다.")
     @Schema(description = "가게명", example = "홍가네")
     private String name;
 
-    @NotNull(message = "가게 지역은 필수입니다.")
     @Schema(description = "가게 지역 ID", example = "KR-11")
     private String regionId;
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreRequest.java
@@ -1,5 +1,6 @@
 package im.fooding.app.dto.request.admin.store;
 
+import im.fooding.core.model.store.StoreCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,52 +16,28 @@ public class AdminUpdateStoreRequest {
     @Schema(description = "가게 지역 ID", example = "KR-11")
     private String regionId;
 
-    @NotBlank(message = "도시는 필수입니다.")
-    @Schema(description = "도시", example = "홍대")
-    private String city;
-
     @NotBlank(message = "주소는 필수입니다.")
     @Schema(description = "주소", example = "서울특별시 마포구")
     private String address;
 
-    @NotBlank(message = "카테고리는 필수입니다.")
-    @Schema(description = "카테고리", example = "한식")
-    private String category;
+    @Schema(description = "주소 상세", example = "마포 빌딩 2층")
+    private String addressDetail;
 
-    @NotBlank(message = "설명은 필수입니다.")
-    @Schema(description = "설명", example = "설명설명")
+    @NotBlank(message = "업종 필수입니다.")
+    @Schema(description = "업종", example = "KOREAN")
+    private StoreCategory category;
+
+    @NotBlank(message = "매장소개는 필수입니다.")
+    @Schema(description = "매장소개", example = "설명설명")
     private String description;
 
-    @NotBlank(message = "가격 카테고리는 필수입니다.")
-    @Schema(description = "가격대", example = "15000 ~ 30000")
-    private String priceCategory;
-
-    @Schema(description = "이벤트설명", example = "이벤트없음")
-    private String eventDescription;
-
-    @NotBlank(message = "연락처는 필수입니다.")
-    @Schema(description = "연락처", example = "010-0000-0000")
+    @NotBlank(message = "매장번호는 필수입니다.")
+    @Schema(description = "매장번호", example = "010-0000-0000")
     private String contactNumber;
 
-    @NotBlank(message = "찾아오는 길은 필수입니다.")
-    @Schema(description = "찾아오는 길", example = "홍대입구역 2번출구 앞")
+    @NotBlank(message = "찾아오시는 길은 필수입니다.")
+    @Schema(description = "찾아오시는 길", example = "홍대입구역 2번출구 앞")
     private String direction;
-
-    @NotBlank(message = "영업 정보는 필수입니다.")
-    @Schema(description = "영업 정보", example = "오전9시 ~ 오후9시")
-    private String information;
-
-    @NotNull(message = "주차 가능 여부는 필수입니다.")
-    @Schema(description = "주차가능여부", example = "true")
-    private Boolean isParkingAvailable;
-
-    @NotNull(message = "신규 오픈 여부는 필수입니다.")
-    @Schema(description = "신규오픈여부", example = "true")
-    private Boolean isNewOpen;
-
-    @NotNull(message = "포장 가능 여부는 필수입니다.")
-    @Schema(description = "포장가능여부", example = "true")
-    private Boolean isTakeOut;
 
     @NotNull(message = "위도 값은 필수입니다.")
     @Schema(description = "위도", example = "36.40947226931638")

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoUpdateStoreRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/CeoUpdateStoreRequest.java
@@ -1,5 +1,6 @@
 package im.fooding.app.dto.request.ceo.store;
 
+import im.fooding.core.model.store.StoreCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -16,52 +17,28 @@ public class CeoUpdateStoreRequest {
     @Schema(description = "가게 지역 ID", example = "KR-11")
     private String regionId;
 
-    @NotBlank(message = "도시는 필수입니다.")
-    @Schema(description = "도시", example = "홍대")
-    private String city;
-
     @NotBlank(message = "주소는 필수입니다.")
     @Schema(description = "주소", example = "서울특별시 마포구")
     private String address;
 
-    @NotBlank(message = "카테고리는 필수입니다.")
-    @Schema(description = "카테고리", example = "한식")
-    private String category;
+    @Schema(description = "주소 상세", example = "마포상가 2층")
+    private String addressDetail;
 
-    @NotBlank(message = "설명은 필수입니다.")
-    @Schema(description = "설명", example = "설명설명")
+    @NotNull(message = "업종 필수입니다.")
+    @Schema(description = "업종", example = "KOREAN")
+    private StoreCategory category;
+
+    @NotBlank(message = "매장소개는 필수입니다.")
+    @Schema(description = "매장소개", example = "설명설명")
     private String description;
 
-    @NotBlank(message = "가격 카테고리는 필수입니다.")
-    @Schema(description = "가격대", example = "15000 ~ 30000")
-    private String priceCategory;
-
-    @Schema(description = "이벤트설명", example = "이벤트없음")
-    private String eventDescription;
-
-    @NotBlank(message = "연락처는 필수입니다.")
-    @Schema(description = "연락처", example = "010-0000-0000")
+    @NotBlank(message = "매장번호는 필수입니다.")
+    @Schema(description = "매장번호", example = "010-0000-0000")
     private String contactNumber;
 
-    @NotBlank(message = "찾아오는 길은 필수입니다.")
-    @Schema(description = "찾아오는 길", example = "홍대입구역 2번출구 앞")
+    @NotBlank(message = "찾아오시는 길은 필수입니다.")
+    @Schema(description = "찾아오시는 길", example = "홍대입구역 2번출구 앞")
     private String direction;
-
-    @NotBlank(message = "영업 정보는 필수입니다.")
-    @Schema(description = "영업 정보", example = "오전9시 ~ 오후9시")
-    private String information;
-
-    @NotNull(message = "주차 가능 여부는 필수입니다.")
-    @Schema(description = "주차가능여부", example = "true")
-    private Boolean isParkingAvailable;
-
-    @NotNull(message = "신규 오픈 여부는 필수입니다.")
-    @Schema(description = "신규오픈여부", example = "true")
-    private Boolean isNewOpen;
-
-    @NotNull(message = "포장 가능 여부는 필수입니다.")
-    @Schema(description = "포장가능여부", example = "true")
-    private Boolean isTakeOut;
 
     @NotNull(message = "위도 값은 필수입니다.")
     @Schema(description = "위도", example = "36.40947226931638")

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/admin/store/AdminStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/admin/store/AdminStoreResponse.java
@@ -1,9 +1,8 @@
 package im.fooding.app.dto.response.admin.store;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import im.fooding.core.dto.request.store.SubwayStationDto;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.model.store.subway.SubwayStation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
@@ -30,44 +29,23 @@ public class AdminStoreResponse {
     @Schema(description = "지역 ID", example = "KR-11", requiredMode = RequiredMode.NOT_REQUIRED)
     private String regionId;
 
-    @Schema(description = "도시", example = "홍대", requiredMode = RequiredMode.REQUIRED)
-    private String city;
-
     @Schema(description = "주소", example = "서울특별시 마포구", requiredMode = RequiredMode.REQUIRED)
     private String address;
 
-    @Schema(description = "카테고리", example = "한식", requiredMode = RequiredMode.REQUIRED)
-    private String category;
+    @Schema(description = "주소 상세", example = "마포빌딩 2층", requiredMode = RequiredMode.NOT_REQUIRED)
+    private String addressDetail;
 
-    @Schema(description = "설명", example = "설명설명", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "업종", example = "KOREAN", requiredMode = RequiredMode.REQUIRED)
+    private StoreCategory category;
+
+    @Schema(description = "매장소개", example = "설명설명", requiredMode = RequiredMode.REQUIRED)
     private String description;
 
-    @Schema(description = "가격대", example = "15000 ~ 30000", requiredMode = RequiredMode.REQUIRED)
-    private String priceCategory;
-
-    @Schema(description = "이벤트설명", example = "이벤트없음", requiredMode = RequiredMode.NOT_REQUIRED)
-    private String eventDescription;
-
-    @Schema(description = "연락처", example = "010-0000-0000", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "매장번호", example = "010-0000-0000", requiredMode = RequiredMode.REQUIRED)
     private String contactNumber;
 
-    @Schema(description = "오시는길", example = "홍대입구역 2번출구 앞", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "찾아오시는길", example = "홍대입구역 2번출구 앞", requiredMode = RequiredMode.REQUIRED)
     private String direction;
-
-    @Schema(description = "영업 정보", example = "오전9시 ~ 오후9시", requiredMode = RequiredMode.REQUIRED)
-    private String information;
-
-    @JsonProperty("isParkingAvailable")
-    @Schema(description = "주차가능여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private boolean isParkingAvailable;
-
-    @JsonProperty("isNewOpen")
-    @Schema(description = "신규오픈여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private boolean isNewOpen;
-
-    @JsonProperty("isTakeOut")
-    @Schema(description = "포장가능여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private boolean isTakeOut;
 
     @Schema(description = "위도", example = "36.40947226931638", requiredMode = RequiredMode.NOT_REQUIRED)
     private Double latitude;
@@ -83,18 +61,12 @@ public class AdminStoreResponse {
         this.ownerId = store.getOwner() != null ? store.getOwner().getId() : null;
         this.name = store.getName();
         this.regionId = store.getRegionId();
-        this.city = store.getCity();
         this.address = store.getAddress();
+        this.addressDetail = store.getAddressDetail();
         this.category = store.getCategory();
         this.description = store.getDescription();
-        this.priceCategory = store.getPriceCategory();
-        this.eventDescription = store.getEventDescription();
         this.contactNumber = store.getContactNumber();
         this.direction = store.getDirection();
-        this.information = store.getInformation();
-        this.isParkingAvailable = store.isParkingAvailable();
-        this.isNewOpen = store.isNewOpen();
-        this.isTakeOut = store.isTakeOut();
         this.latitude = store.getLatitude();
         this.longitude = store.getLongitude();
         this.stations = new ArrayList<>();

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/app/store/AppStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/app/store/AppStoreResponse.java
@@ -1,6 +1,7 @@
 package im.fooding.app.dto.response.app.store;
 
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 
@@ -12,59 +13,35 @@ public record AppStoreResponse(
         @Schema(description = "가게 이름", requiredMode = RequiredMode.REQUIRED)
         String name,
 
-        @Schema(description = "매장 위치", requiredMode = RequiredMode.REQUIRED)
-        String city,
-
         @Schema(description = "매장 주소", requiredMode = RequiredMode.REQUIRED)
         String address,
 
+        @Schema(description = "매장 주소 상세", requiredMode = RequiredMode.NOT_REQUIRED)
+        String addressDetail,
+
         @Schema(description = "매장 카테코리", requiredMode = RequiredMode.REQUIRED)
-        String category,
+        StoreCategory category,
 
         @Schema(description = "매장 소개", requiredMode = RequiredMode.REQUIRED)
         String description,
-
-        @Schema(description = "평균 가격대", requiredMode = RequiredMode.REQUIRED)
-        String priceCategory,
-
-        @Schema(description = "매장 이벤트 소개")
-        String eventDescription,
 
         @Schema(description = "매장 전화번호", requiredMode = RequiredMode.REQUIRED)
         String contactNumber,
 
         @Schema(description = "찾아오는 방법", requiredMode = RequiredMode.REQUIRED)
-        String direction,
-
-        @Schema(description = "안내 및 유의 사항", requiredMode = RequiredMode.REQUIRED)
-        String information,
-
-        @Schema(description = "주차 가능 여부", requiredMode = RequiredMode.REQUIRED)
-        boolean isParkingAvailable,
-
-        @Schema(description = "매장 신규오픈 여부", requiredMode = RequiredMode.REQUIRED)
-        boolean isNewOpen,
-
-        @Schema(description = "매장 테이크아웃 여부", requiredMode = RequiredMode.REQUIRED)
-        boolean isTakeOut
+        String direction
 ) {
 
     public static AppStoreResponse from(Store store) {
         return new AppStoreResponse(
                 store.getId(),
                 store.getName(),
-                store.getCity(),
                 store.getAddress(),
+                store.getAddressDetail(),
                 store.getCategory(),
                 store.getDescription(),
-                store.getPriceCategory(),
-                store.getEventDescription(),
                 store.getContactNumber(),
-                store.getDirection(),
-                store.getInformation(),
-                store.isParkingAvailable(),
-                store.isNewOpen(),
-                store.isTakeOut()
+                store.getDirection()
         );
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreResponse.java
@@ -1,7 +1,7 @@
 package im.fooding.app.dto.response.ceo.store;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.model.store.subway.SubwayStation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
@@ -23,44 +23,23 @@ public class CeoStoreResponse {
     @Schema(description = "지역 ID", example = "KR-11", requiredMode = RequiredMode.NOT_REQUIRED)
     private final String regionId;
 
-    @Schema(description = "도시", example = "홍대", requiredMode = RequiredMode.REQUIRED)
-    private final String city;
-
     @Schema(description = "주소", example = "서울특별시 마포구", requiredMode = RequiredMode.REQUIRED)
     private final String address;
 
-    @Schema(description = "카테고리", example = "한식", requiredMode = RequiredMode.REQUIRED)
-    private final String category;
+    @Schema(description = "주소 상세", example = "마포빌딩 2층", requiredMode = RequiredMode.NOT_REQUIRED)
+    private final String addressDetail;
 
-    @Schema(description = "설명", example = "설명설명", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "업종", example = "KOREAN", requiredMode = RequiredMode.REQUIRED)
+    private final StoreCategory category;
+
+    @Schema(description = "매장소개", example = "설명설명", requiredMode = RequiredMode.REQUIRED)
     private final String description;
 
-    @Schema(description = "가격대", example = "15000 ~ 30000", requiredMode = RequiredMode.REQUIRED)
-    private final String priceCategory;
-
-    @Schema(description = "이벤트설명", example = "이벤트없음", requiredMode = RequiredMode.NOT_REQUIRED)
-    private final String eventDescription;
-
-    @Schema(description = "연락처", example = "010-0000-0000", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "매장번호", example = "010-0000-0000", requiredMode = RequiredMode.REQUIRED)
     private final String contactNumber;
 
-    @Schema(description = "오시는길", example = "홍대입구역 2번출구 앞", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "찾아오시는길", example = "홍대입구역 2번출구 앞", requiredMode = RequiredMode.REQUIRED)
     private final String direction;
-
-    @Schema(description = "영업 정보", example = "오전9시 ~ 오후9시", requiredMode = RequiredMode.REQUIRED)
-    private final String information;
-
-    @JsonProperty("isParkingAvailable")
-    @Schema(description = "주차가능여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private final boolean isParkingAvailable;
-
-    @JsonProperty("isNewOpen")
-    @Schema(description = "신규오픈여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private final boolean isNewOpen;
-
-    @JsonProperty("isTakeOut")
-    @Schema(description = "포장가능여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private final boolean isTakeOut;
 
     @Schema(description = "위도", example = "36.40947226931638", requiredMode = RequiredMode.REQUIRED)
     private final Double latitude;
@@ -77,7 +56,7 @@ public class CeoStoreResponse {
     @Schema(description = "해당 가게의 총 관심 수", example = "100", requiredMode = RequiredMode.REQUIRED)
     private final int bookmarkCount;
 
-    @Schema(description = "인근 지하철역", example="홍대입구역 2호선", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "인근 지하철역", example = "홍대입구역 2호선", requiredMode = RequiredMode.REQUIRED)
     private final List<SubwayStation> stations;
 
     public CeoStoreResponse(Store store) {
@@ -85,18 +64,12 @@ public class CeoStoreResponse {
         this.ownerId = store.getOwner() != null ? store.getOwner().getId() : null;
         this.regionId = store.getRegionId();
         this.name = store.getName();
-        this.city = store.getCity();
         this.address = store.getAddress();
+        this.addressDetail = store.getAddressDetail();
         this.category = store.getCategory();
         this.description = store.getDescription();
-        this.priceCategory = store.getPriceCategory();
-        this.eventDescription = store.getEventDescription();
         this.contactNumber = store.getContactNumber();
         this.direction = store.getDirection();
-        this.information = store.getInformation();
-        this.isParkingAvailable = store.isParkingAvailable();
-        this.isNewOpen = store.isNewOpen();
-        this.isTakeOut = store.isTakeOut();
         this.latitude = store.getLatitude();
         this.longitude = store.getLongitude();
         this.visitCount = store.getVisitCount();

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/bookmark/UserBookmarkResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/bookmark/UserBookmarkResponse.java
@@ -25,9 +25,6 @@ public class UserBookmarkResponse {
     @Schema(description = "가게명", example = "홍길동 식당", requiredMode = RequiredMode.REQUIRED)
     private String name;
 
-    @Schema(description = "가게가 위치한 도시", example = "합정", requiredMode = RequiredMode.REQUIRED)
-    private String city;
-
     @Schema(description = "해당 가게의 총 방문수", example = "1000", requiredMode = RequiredMode.REQUIRED)
     private int visitCount;
 
@@ -50,11 +47,10 @@ public class UserBookmarkResponse {
     private List<UserStoreImageResponse> images;
 
     @Builder
-    private UserBookmarkResponse(Long id, Long storeId, String name, String city, int visitCount, int reviewCount, int bookmarkCount, double averageRating, Integer estimatedWaitingTimeMinutes, List<UserStoreImageResponse> images) {
+    private UserBookmarkResponse(Long id, Long storeId, String name, int visitCount, int reviewCount, int bookmarkCount, double averageRating, Integer estimatedWaitingTimeMinutes, List<UserStoreImageResponse> images) {
         this.id = id;
         this.storeId = storeId;
         this.name = name;
-        this.city = city;
         this.visitCount = visitCount;
         this.reviewCount = reviewCount;
         this.bookmarkCount = bookmarkCount;
@@ -74,7 +70,6 @@ public class UserBookmarkResponse {
                 .id(store.getId())
                 .storeId(store.getId())
                 .name(store.getName())
-                .city(store.getCity())
                 .visitCount(store.getVisitCount())
                 .reviewCount(store.getReviewCount())
                 .bookmarkCount(store.getBookmarkCount())

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreListResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreListResponse.java
@@ -20,9 +20,6 @@ public class UserStoreListResponse {
     @Schema(description = "가게 이미지 URL", example = "https://example.com/store.jpg", requiredMode = RequiredMode.NOT_REQUIRED)
     private String mainImage;
 
-    @Schema(description = "가게가 위치한 도시", example = "합정", requiredMode = RequiredMode.REQUIRED)
-    private String city;
-
     @Schema(description = "해당 가게의 총 방문수", example = "1000", requiredMode = RequiredMode.REQUIRED)
     private int visitCount;
 
@@ -45,12 +42,11 @@ public class UserStoreListResponse {
     private Boolean isBookmarked = false;
 
     @Builder
-    private UserStoreListResponse(Long id, String name, String image, String city, double averageRating, int visitCount,
+    private UserStoreListResponse(Long id, String name, String image, double averageRating, int visitCount,
                                   int reviewCount, int bookmarkCount, Integer estimatedWaitingTimeMinutes) {
         this.id = id;
         this.name = name;
         this.mainImage = image;
-        this.city = city;
         this.visitCount = visitCount;
         this.reviewCount = reviewCount;
         this.bookmarkCount = bookmarkCount;
@@ -64,7 +60,6 @@ public class UserStoreListResponse {
                 .id(store.getId())
                 .name(store.getName())
                 .image(imageUrl)
-                .city(store.getCity())
                 .visitCount(store.getVisitCount())
                 .reviewCount(store.getReviewCount())
                 .bookmarkCount(store.getBookmarkCount())

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreResponse.java
@@ -1,6 +1,7 @@
 package im.fooding.app.dto.response.user.store;
 
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.model.store.StoreImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
@@ -20,28 +21,22 @@ public class UserStoreResponse {
     @Schema(description = "가게명", example = "홍길동 식당", requiredMode = RequiredMode.REQUIRED)
     private String name;
 
-    @Schema(description = "가게가 위치한 도시", example = "합정", requiredMode = RequiredMode.REQUIRED)
-    private String city;
-
     @Schema(description = "주소", example = "서울특별시 마포구", requiredMode = RequiredMode.REQUIRED)
     private String address;
 
-    @Schema(description = "카테고리", example = "한식", requiredMode = RequiredMode.REQUIRED)
-    private String category;
+    @Schema(description = "주소 상세", example = "마포빌딩 2층", requiredMode = RequiredMode.REQUIRED)
+    private String addressDetail;
 
-    @Schema(description = "설명", example = "설명설명", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "업종", example = "KOREAN", requiredMode = RequiredMode.REQUIRED)
+    private StoreCategory category;
+
+    @Schema(description = "매장소개", example = "설명설명", requiredMode = RequiredMode.REQUIRED)
     private String description;
 
-    @Schema(description = "가격대", example = "15000 ~ 30000", requiredMode = RequiredMode.REQUIRED)
-    private String priceCategory;
-
-    @Schema(description = "이벤트설명", example = "이벤트없음", requiredMode = RequiredMode.NOT_REQUIRED)
-    private String eventDescription;
-
-    @Schema(description = "연락처", example = "010-0000-0000", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "매장번호", example = "010-0000-0000", requiredMode = RequiredMode.REQUIRED)
     private String contactNumber;
 
-    @Schema(description = "오시는길", example = "홍대입구역 2번출구 앞", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "찾아오시는길", example = "홍대입구역 2번출구 앞", requiredMode = RequiredMode.REQUIRED)
     private String direction;
 
     @Schema(description = "해당 가게의 총 방문수", example = "1000", requiredMode = RequiredMode.REQUIRED)
@@ -55,15 +50,6 @@ public class UserStoreResponse {
 
     @Schema(description = "해당 가게의 총 리뷰 평점", example = "4.5", requiredMode = RequiredMode.REQUIRED)
     private double averageRating;
-
-    @Schema(description = "주차가능여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private Boolean isParkingAvailable;
-
-    @Schema(description = "신규오픈여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private Boolean isNewOpen;
-
-    @Schema(description = "포장가능여부", example = "true", requiredMode = RequiredMode.REQUIRED)
-    private Boolean isTakeOut;
 
     @Schema(description = "해당 가게의 평균 대기 시간 (웨이팅이 비활성화된 가게일 경우, null 반환)", example = "20", requiredMode = RequiredMode.NOT_REQUIRED)
     private Integer estimatedWaitingTimeMinutes;
@@ -84,27 +70,20 @@ public class UserStoreResponse {
     private List<UserStoreImageResponse> images;
 
     @Builder
-    private UserStoreResponse(Long id, String name, String city, String address, String category, String description,
-                              String priceCategory, String eventDescription, String contactNumber, String direction, int visitCount,
-                              int reviewCount, int bookmarkCount, double averageRating, Boolean isParkingAvailable, Boolean isNewOpen, Boolean isTakeOut,
+    private UserStoreResponse(Long id, String name, String address, String addressDetail, StoreCategory category, String description,
+                              String contactNumber, String direction, int visitCount, int reviewCount, int bookmarkCount, double averageRating,
                               Integer estimatedWaitingTimeMinutes, Double latitude, Double longitude, List<UserStoreImageResponse> images) {
         this.id = id;
         this.name = name;
-        this.city = city;
         this.address = address;
         this.category = category;
         this.description = description;
-        this.priceCategory = priceCategory;
-        this.eventDescription = eventDescription;
         this.contactNumber = contactNumber;
         this.direction = direction;
         this.visitCount = visitCount;
         this.reviewCount = reviewCount;
         this.bookmarkCount = bookmarkCount;
         this.averageRating = averageRating;
-        this.isParkingAvailable = isParkingAvailable;
-        this.isNewOpen = isNewOpen;
-        this.isTakeOut = isTakeOut;
         this.estimatedWaitingTimeMinutes = estimatedWaitingTimeMinutes;
         this.latitude = latitude;
         this.longitude = longitude;
@@ -120,21 +99,16 @@ public class UserStoreResponse {
         return UserStoreResponse.builder()
                 .id(store.getId())
                 .name(store.getName())
-                .city(store.getCity())
                 .address(store.getAddress())
+                .addressDetail(store.getAddressDetail())
                 .category(store.getCategory())
                 .description(store.getDescription())
-                .priceCategory(store.getPriceCategory())
-                .eventDescription(store.getEventDescription())
                 .contactNumber(store.getContactNumber())
                 .direction(store.getDirection())
                 .visitCount(store.getVisitCount())
                 .reviewCount(store.getReviewCount())
                 .bookmarkCount(store.getBookmarkCount())
                 .averageRating(store.getAverageRating())
-                .isParkingAvailable(store.isParkingAvailable())
-                .isNewOpen(store.isNewOpen())
-                .isTakeOut(store.isTakeOut())
                 .estimatedWaitingTimeMinutes(estimatedWaitingTime)
                 .latitude(store.getLatitude())
                 .longitude(store.getLongitude())

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/store/AdminStoreService.java
@@ -17,7 +17,6 @@ import im.fooding.core.model.user.User;
 import im.fooding.core.service.region.RegionService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
-import im.fooding.core.service.store.document.StoreDocumentService;
 import im.fooding.core.service.store.subway.SubwayStationService;
 import im.fooding.core.service.user.UserAuthorityService;
 import im.fooding.core.service.user.UserService;
@@ -42,7 +41,6 @@ public class AdminStoreService {
     private final UserAuthorityService userAuthorityService;
     private final RegionService regionService;
     private final SubwayStationService subwayStationService;
-    private final StoreDocumentService storeDocumentService;
     private final EventProducerService eventProducerService;
 
     @Transactional(readOnly = true)
@@ -68,10 +66,9 @@ public class AdminStoreService {
 
         userAuthorityService.checkPermission(user.getAuthorities(), Role.CEO);
 
-        Store store = storeService.create(user, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(),
-                request.getDescription(), request.getPriceCategory(), request.getEventDescription(), request.getContactNumber(),
-                request.getDirection(), request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(),
-                request.getIsTakeOut(), request.getLatitude(), request.getLongitude());
+        Store store = storeService.create(user, request.getName(), region, request.getAddress(), request.getAddressDetail(), request.getCategory(),
+                request.getDescription(), request.getContactNumber(), request.getDirection(), false, false,
+                request.getLatitude(), request.getLongitude());
 
         storeMemberService.create(store, user, StorePosition.OWNER);
         eventProducerService.publishEvent("StoreCreatedEvent", new StoreCreatedEvent(store.getId(), store.getName(), store.getCategory(), store.getAddress(), store.getReviewCount(), store.getAverageRating(), store.getVisitCount(), store.getCreatedAt()));
@@ -85,9 +82,9 @@ public class AdminStoreService {
 
         List<SubwayStation> nearStations = subwayStationService.getNearStations(request.getLatitude(), request.getLongitude());
 
-        Store store = storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
-                request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
-                request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude(), nearStations);
+        Store store = storeService.update(id, request.getName(), region, request.getAddress(), request.getAddressDetail(), request.getCategory(),
+                request.getDescription(), request.getContactNumber(), request.getDirection(), false, false, request.getLatitude(), request.getLongitude(), nearStations);
+
         eventProducerService.publishEvent("StoreUpdatedEvent", new StoreCreatedEvent(store.getId(), store.getName(), store.getCategory(), store.getAddress(), store.getReviewCount(), store.getAverageRating(), store.getVisitCount(), store.getCreatedAt()));
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreService.java
@@ -8,6 +8,7 @@ import im.fooding.core.event.store.StoreCreatedEvent;
 import im.fooding.core.global.kafka.EventProducerService;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.model.store.StorePosition;
 import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.User;
@@ -51,8 +52,8 @@ public class CeoStoreService {
     public Long create(CeoCreateStoreRequest request, long userId) {
         User user = userService.findById(userId);
 
-        Store store = storeService.create(user, request.getName(), null, "", "", "",
-                "", "", "", "", "", "", true, true, true, null, null);
+        Store store = storeService.create(user, request.getName(), null, "", "", StoreCategory.KOREAN,
+                "", "", "", false, false, null, null);
 
         storeMemberService.create(store, user, StorePosition.OWNER);
         eventProducerService.publishEvent("StoreCreatedEvent", new StoreCreatedEvent(store.getId(), store.getName(), store.getCategory(), store.getAddress(), store.getReviewCount(), store.getAverageRating(), store.getVisitCount(), store.getCreatedAt()));
@@ -67,9 +68,8 @@ public class CeoStoreService {
         // 주소를 통해 인근 지하철역 조회 ( 1km 반경 내 )
         List<SubwayStation> nearStations = subwayStationService.getNearStations(request.getLatitude(), request.getLongitude());
 
-        Store store = storeService.update(id, request.getName(), region, request.getCity(), request.getAddress(), request.getCategory(), request.getDescription(),
-                request.getContactNumber(), request.getPriceCategory(), request.getEventDescription(), request.getDirection(),
-                request.getInformation(), request.getIsParkingAvailable(), request.getIsNewOpen(), request.getIsTakeOut(), request.getLatitude(), request.getLongitude(), nearStations);
+        Store store = storeService.update(id, request.getName(), region, request.getAddress(), request.getAddressDetail(), request.getCategory(), request.getDescription(),
+                request.getContactNumber(), request.getDirection(), false, false, request.getLatitude(), request.getLongitude(), nearStations);
 
         eventProducerService.publishEvent("StoreUpdatedEvent", new StoreCreatedEvent(store.getId(), store.getName(), store.getCategory(), store.getAddress(), store.getReviewCount(), store.getAverageRating(), store.getVisitCount(), store.getCreatedAt()));
     }

--- a/fooding-core/src/main/java/im/fooding/core/event/store/StoreCreatedEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/store/StoreCreatedEvent.java
@@ -1,6 +1,7 @@
 package im.fooding.core.event.store;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import im.fooding.core.model.store.StoreCategory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ public class StoreCreatedEvent {
 
     private String name;
 
-    private String category;
+    private StoreCategory category;
 
     private String address;
 

--- a/fooding-core/src/main/java/im/fooding/core/event/store/StoreUpdatedEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/store/StoreUpdatedEvent.java
@@ -1,6 +1,7 @@
 package im.fooding.core.event.store;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import im.fooding.core.model.store.StoreCategory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ public class StoreUpdatedEvent {
 
     private String name;
 
-    private String category;
+    private StoreCategory category;
 
     private String address;
 

--- a/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/Store.java
@@ -5,15 +5,14 @@ import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.User;
 import jakarta.persistence.*;
-
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.List;
 
 
 @Entity
@@ -36,36 +35,23 @@ public class Store extends BaseEntity {
     @JoinColumn(name = "region_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Region region;
 
-    @Column(name = "city", nullable = false)
-    private String city;
-
     @Column(name = "address", nullable = false)
     private String address;
 
+    private String addressDetail;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)
-    private String category;
+    private StoreCategory category;
 
     @Column(name = "description", nullable = false)
     private String description;
-
-    @Column(name = "price_category", nullable = false)
-    private String priceCategory;
-
-    @Column(name = "event_description")
-    private String eventDescription;
 
     @Column(name = "contact_number", nullable = false)
     private String contactNumber;
 
     @Column(nullable = false)
     private String direction;
-
-    @Column(nullable = false)
-    private String information;
-
-    @Column(nullable = false)
-    @ColumnDefault("false")
-    private boolean isParkingAvailable;
 
     @Column(nullable = false)
     private boolean isNewOpen;
@@ -94,38 +80,29 @@ public class Store extends BaseEntity {
     private List<StoreImage> images;
 
     @Builder
-    private Store(
-            User owner,
-            String name,
-            Region region,
-            String city,
-            String address,
-            String category,
-            String description,
-            String contactNumber,
-            String priceCategory,
-            String eventDescription,
-            String direction,
-            String information,
-            boolean isParkingAvailable,
-            boolean isNewOpen,
-            boolean isTakeOut,
-            Double latitude,
-            Double longitude
+    private Store(User owner,
+                  String name,
+                  Region region,
+                  String address,
+                  String addressDetail,
+                  StoreCategory category,
+                  String description,
+                  String contactNumber,
+                  String direction,
+                  boolean isNewOpen,
+                  boolean isTakeOut,
+                  Double latitude,
+                  Double longitude
     ) {
         this.owner = owner;
         this.name = name;
         this.region = region;
-        this.city = city;
         this.address = address;
+        this.addressDetail = addressDetail;
         this.category = category;
         this.description = description;
         this.contactNumber = contactNumber;
-        this.priceCategory = priceCategory;
-        this.eventDescription = eventDescription;
         this.direction = direction;
-        this.information = information;
-        this.isParkingAvailable = isParkingAvailable;
         this.isNewOpen = isNewOpen;
         this.isTakeOut = isTakeOut;
         this.latitude = latitude;
@@ -136,16 +113,12 @@ public class Store extends BaseEntity {
     public void update(
             String name,
             Region region,
-            String city,
             String address,
-            String category,
+            String addressDetail,
+            StoreCategory category,
             String description,
             String contactNumber,
-            String priceCategory,
-            String eventDescription,
             String direction,
-            String information,
-            boolean isParkingAvailable,
             boolean isNewOpen,
             boolean isTakeOut,
             Double latitude,
@@ -153,16 +126,12 @@ public class Store extends BaseEntity {
     ) {
         this.name = name;
         this.region = region;
-        this.city = city;
         this.address = address;
+        this.addressDetail = addressDetail;
         this.category = category;
         this.description = description;
         this.contactNumber = contactNumber;
-        this.priceCategory = priceCategory;
-        this.eventDescription = eventDescription;
         this.direction = direction;
-        this.information = information;
-        this.isParkingAvailable = isParkingAvailable;
         this.isNewOpen = isNewOpen;
         this.isTakeOut = isTakeOut;
         this.latitude = latitude;
@@ -193,7 +162,7 @@ public class Store extends BaseEntity {
         this.bookmarkCount--;
     }
 
-    public void setNearSubwayStations(List<SubwayStation> stations){
+    public void setNearSubwayStations(List<SubwayStation> stations) {
         this.subwayStations = stations;
     }
 

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StoreCategory.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StoreCategory.java
@@ -6,22 +6,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum StoreCategory {
-    KOREAN("한식"),
-    JAPANESE("일식"),
-    CHINESE("중식"),
-    WESTERN("양식"),
-    ASIAN("아시안푸드"),
-
+    PORK("족발/보쌈"),
+    MEAT("고기"),
     CHICKEN("치킨"),
-    PORK_FEET("족발보쌈"),
-    BBQ("고기"),
-    STREET_FOOD("분식"),
-    BURGER_SALAD("햄버거샐러드"),
-    LUNCHBOX_PORRIDGE("도시락죽"),
-
+    JAPANESE("일식"),
+    WESTERN("양식"),
+    CHINESE("중식"),
+    KOREAN("한식"),
+    ASIAN("아시안 푸드"),
+    LUNCHBOX_PORRIDGE("도시락/죽"),
+    CAFE_DESSERT("카페/디저트"),
+    BURGER("햄버거"),
+    SALAD("샐러드"),
+    SNACK("분식"),
     SEAFOOD("수산물"),
-    SNACKS("술안주"),
-    CAFE_DESSERT("카페디저트");
+    SIDE_DISH("술안주"),
+    ;
 
     private final String name;
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StoreCategory.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StoreCategory.java
@@ -1,0 +1,27 @@
+package im.fooding.core.model.store;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum StoreCategory {
+    KOREAN("한식"),
+    JAPANESE("일식"),
+    CHINESE("중식"),
+    WESTERN("양식"),
+    ASIAN("아시안푸드"),
+
+    CHICKEN("치킨"),
+    PORK_FEET("족발보쌈"),
+    BBQ("고기"),
+    STREET_FOOD("분식"),
+    BURGER_SALAD("햄버거샐러드"),
+    LUNCHBOX_PORRIDGE("도시락죽"),
+
+    SEAFOOD("수산물"),
+    SNACKS("술안주"),
+    CAFE_DESSERT("카페디저트");
+
+    private final String name;
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/store/document/StoreDocument.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/document/StoreDocument.java
@@ -1,8 +1,6 @@
 package im.fooding.core.model.store.document;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import im.fooding.core.event.store.StoreCreatedEvent;
-import im.fooding.core.model.store.Store;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,33 +39,6 @@ public class StoreDocument {
         this.visitCount = visitCount;
         this.createdAt = createdAt;
     }
-
-    public static StoreDocument from(Store store) {
-        return StoreDocument.builder()
-                .id(store.getId())
-                .name(store.getName())
-                .category(store.getCategory())
-                .address(store.getAddress())
-                .reviewCount(store.getReviewCount())
-                .averageRating(store.getAverageRating())
-                .visitCount(store.getVisitCount())
-                .createdAt(store.getCreatedAt())
-                .build();
-    }
-
-    public static StoreDocument of(StoreCreatedEvent event) {
-        return StoreDocument.builder()
-                .id(event.getId())
-                .name(event.getName())
-                .category(event.getCategory())
-                .address(event.getAddress())
-                .reviewCount(event.getReviewCount())
-                .averageRating(event.getAverageRating())
-                .visitCount(event.getVisitCount())
-                .createdAt(event.getCreatedAt())
-                .build();
-    }
-
 
     public String getIndex() {
         return "stores_v1";

--- a/fooding-core/src/main/java/im/fooding/core/repository/elasticsearch/store/StoreDocumentRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/elasticsearch/store/StoreDocumentRepository.java
@@ -1,9 +1,0 @@
-//package im.fooding.core.repository.elasticsearch.store;
-//
-//import im.fooding.core.model.store.document.StoreDocument;
-//import org.springframework.context.annotation.Profile;
-//import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-//
-//@Profile("!test")
-//public interface StoreDocumentRepository extends ElasticsearchRepository<StoreDocument,String> {
-//}

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreService.java
@@ -10,6 +10,7 @@ import im.fooding.core.global.infra.slack.SlackClient;
 import im.fooding.core.global.kafka.KafkaEventHandler;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.model.store.StoreSortType;
 import im.fooding.core.model.store.subway.SubwayStation;
 import im.fooding.core.model.user.User;
@@ -87,16 +88,12 @@ public class StoreService {
             User owner,
             String name,
             Region region,
-            String city,
             String address,
-            String category,
+            String addressDetail,
+            StoreCategory category,
             String description,
-            String priceCategory,
-            String eventDescription,
             String contactNumber,
             String direction,
-            String information,
-            boolean isParkingAvailable,
             boolean isNewOpen,
             boolean isTakeOut,
             Double latitude,
@@ -106,16 +103,12 @@ public class StoreService {
                 .owner(owner)
                 .name(name)
                 .region(region)
-                .city(city)
                 .address(address)
+                .addressDetail(addressDetail)
                 .category(category)
                 .description(description)
-                .priceCategory(priceCategory)
-                .eventDescription(eventDescription)
                 .contactNumber(contactNumber)
                 .direction(direction)
-                .information(information)
-                .isParkingAvailable(isParkingAvailable)
                 .isNewOpen(isNewOpen)
                 .isTakeOut(isTakeOut)
                 .latitude(latitude)
@@ -128,16 +121,12 @@ public class StoreService {
             long id,
             String name,
             Region region,
-            String city,
             String address,
-            String category,
+            String addressDetail,
+            StoreCategory category,
             String description,
             String contactNumber,
-            String priceCategory,
-            String eventDescription,
             String direction,
-            String information,
-            boolean isParkingAvailable,
             boolean isNewOpen,
             boolean isTakeOut,
             Double latitude,
@@ -145,8 +134,7 @@ public class StoreService {
             List<SubwayStation> stations
     ) {
         Store store = findById(id);
-        store.update(name, region, city, address, category, description, contactNumber, priceCategory, eventDescription,
-                direction, information, isParkingAvailable, isNewOpen, isTakeOut, latitude, longitude);
+        store.update(name, region, address, addressDetail, category, description, contactNumber, direction, isNewOpen, isTakeOut, latitude, longitude);
         store.setNearSubwayStations(stations);
         return store;
     }

--- a/fooding-core/src/main/java/im/fooding/core/service/store/document/StoreDocumentService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/document/StoreDocumentService.java
@@ -10,6 +10,7 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.model.store.StoreSortType;
 import im.fooding.core.model.store.document.StoreDocument;
 import lombok.RequiredArgsConstructor;
@@ -34,11 +35,11 @@ public class StoreDocumentService {
     private final ElasticsearchClient client;
     private final ObjectMapper objectMapper;
 
-    public void save(Long id, String name, String category, String address, int reviewCount, double averageRating, int visitCount, LocalDateTime createdAt) throws IOException {
+    public void save(Long id, String name, StoreCategory category, String address, int reviewCount, double averageRating, int visitCount, LocalDateTime createdAt) throws IOException {
         StoreDocument storeDocument = StoreDocument.builder()
                 .id(id)
                 .name(name)
-                .category(category)
+                .category(category.name())
                 .address(address)
                 .reviewCount(reviewCount)
                 .averageRating(averageRating)

--- a/fooding-core/src/test/java/im/fooding/core/service/coupon/CouponServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/coupon/CouponServiceTest.java
@@ -7,6 +7,7 @@ import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.coupon.*;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.repository.coupon.CouponRepository;
 import im.fooding.core.repository.region.RegionRepository;
 import im.fooding.core.repository.store.StoreRepository;
@@ -199,14 +200,11 @@ class CouponServiceTest extends TestConfig {
         Store store = Store.builder()
                 .name("테스트가게")
                 .region(saveRegion())
-                .city("테스트")
                 .address("테스트")
-                .category("테스트")
+                .category(StoreCategory.KOREAN)
                 .description("테스트")
-                .priceCategory("테스트")
                 .contactNumber("테스트")
                 .direction("테스트")
-                .information("테스트")
                 .build();
         return storeRepository.save(store);
     }

--- a/fooding-core/src/test/java/im/fooding/core/service/coupon/UserCouponServiceTest.java
+++ b/fooding-core/src/test/java/im/fooding/core/service/coupon/UserCouponServiceTest.java
@@ -7,6 +7,7 @@ import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.coupon.*;
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 import im.fooding.core.model.user.*;
 import im.fooding.core.repository.coupon.CouponRepository;
 import im.fooding.core.repository.coupon.UserCouponRepository;
@@ -212,14 +213,11 @@ class UserCouponServiceTest extends TestConfig {
         Store store = Store.builder()
                 .name("테스트가게")
                 .region(saveRegion())
-                .city("테스트")
                 .address("테스트")
-                .category("테스트")
+                .category(StoreCategory.KOREAN)
                 .description("테스트")
-                .priceCategory("테스트")
                 .contactNumber("테스트")
                 .direction("테스트")
-                .information("테스트")
                 .build();
         return storeRepository.save(store);
     }

--- a/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
+++ b/fooding-core/src/test/java/im/fooding/core/support/dummy/StoreDummy.java
@@ -2,22 +2,18 @@ package im.fooding.core.support.dummy;
 
 import im.fooding.core.model.region.Region;
 import im.fooding.core.model.store.Store;
+import im.fooding.core.model.store.StoreCategory;
 
 public class StoreDummy {
 
     public static Store create() {
         return Store.builder()
                 .name("name")
-                .city("city")
                 .address("address")
-                .category("category")
+                .category(StoreCategory.KOREAN)
                 .description("description")
                 .contactNumber("01012345678")
-                .priceCategory("priceCategory")
-                .eventDescription("eventDescription")
                 .direction("direction")
-                .information("information")
-                .isParkingAvailable(true)
                 .isNewOpen(true)
                 .isTakeOut(true)
                 .build();
@@ -27,16 +23,11 @@ public class StoreDummy {
         return Store.builder()
                 .name("name")
                 .region(region)
-                .city("city")
                 .address("address")
-                .category("category")
+                .category(StoreCategory.KOREAN)
                 .description("description")
                 .contactNumber("01012345678")
-                .priceCategory("priceCategory")
-                .eventDescription("eventDescription")
                 .direction("direction")
-                .information("information")
-                .isParkingAvailable(true)
                 .isNewOpen(true)
                 .isTakeOut(true)
                 .build();


### PR DESCRIPTION
## 이슈
[BE-292](https://www.notion.so/benkang/Store-CEO-API-25483feabad380d4923be358a4a8c878?source=copy_link)
[BE-294](https://www.notion.so/benkang/Store-25883feabad38025827dc8dcdce6d904?source=copy_link)

## 내용
CEO 피그마 화면 기준으로 필드 변경했습니다.
stage store 테이블은 반영 완료 하였으나 main 쪽은 db 접속 정보를 몰라서 머지할 때 @titaniper 님과 같이 진행해야 할 듯 합니다.

제거
- city 
- priceCategory
- eventDescription
- information
- isParkingAvailable

추가
- addressDetail

변경
- category enum으로 변경