### PR TITLE
[BE-306] USER 웨이팅/예약 상세 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/user/plan/UserPlanController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/plan/UserPlanController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,5 +31,11 @@ public class UserPlanController {
             @ModelAttribute UserPlanRetrieveRequest request
     ) {
         return ApiResult.ok(userPlanService.list(request, userInfo.getId()));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "플랜 상세 조회")
+    ApiResult<UserPlanResponse> get(@PathVariable String id) {
+        return ApiResult.ok(userPlanService.getPlan(id));
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/waiting/UserStoreWaitingResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/waiting/UserStoreWaitingResponse.java
@@ -2,6 +2,7 @@ package im.fooding.app.dto.response.user.waiting;
 
 import im.fooding.core.model.waiting.StoreWaiting;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.Value;
 
 @Value
@@ -34,6 +35,9 @@ public class UserStoreWaitingResponse {
     @Schema(description = "메모", example = "메모 내용입니다.")
     String memo;
 
+    @Schema(description = "등록 일시", example = "2025-07-30T06:01:16.711Z")
+    LocalDateTime registeredAt;
+
     public static UserStoreWaitingResponse from(StoreWaiting waiting) {
         Long userId = null;
         if (waiting.getUser() != null) {
@@ -52,7 +56,8 @@ public class UserStoreWaitingResponse {
                 waiting.getInfantCount(),
                 waiting.getAdultCount(),
                 waiting.getCallNumber(),
-                waiting.getMemo()
+                waiting.getMemo(),
+                waiting.getCreatedAt()
         );
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/waiting/UserStoreWaitingResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/waiting/UserStoreWaitingResponse.java
@@ -28,6 +28,9 @@ public class UserStoreWaitingResponse {
     @Schema(description = "성인 수", example = "1")
     Integer adultCount;
 
+    @Schema(description = "호출 번호", example = "1")
+    int callNumber;
+
     @Schema(description = "메모", example = "메모 내용입니다.")
     String memo;
 
@@ -48,6 +51,7 @@ public class UserStoreWaitingResponse {
                 waiting.getInfantChairCount(),
                 waiting.getInfantCount(),
                 waiting.getAdultCount(),
+                waiting.getCallNumber(),
                 waiting.getMemo()
         );
     }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/plan/UserPlanService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/plan/UserPlanService.java
@@ -4,9 +4,12 @@ import im.fooding.app.dto.request.user.plan.UserPlanRetrieveRequest;
 import im.fooding.app.dto.response.user.plan.UserPlanResponse;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.plan.Plan;
 import im.fooding.core.service.plan.PlanService;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
@@ -21,5 +24,9 @@ public class UserPlanService {
         Page<UserPlanResponse> planResponses = plans.map(UserPlanResponse::from);
 
         return PageResponse.of(planResponses.toList(), PageInfo.of(planResponses));
+    }
+
+    public UserPlanResponse getPlan(String id) {
+        return UserPlanResponse.from(planService.getPlan(new ObjectId(id)));
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/plan/PlanService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/plan/PlanService.java
@@ -1,5 +1,7 @@
 package im.fooding.core.service.plan;
 
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.plan.Plan;
 import im.fooding.core.model.plan.Plan.ReservationType;
 import im.fooding.core.model.plan.Plan.VisitStatus;
@@ -49,5 +51,11 @@ public class PlanService {
 
     public Page<Plan> list(Long userId, Pageable pageable) {
         return planRepository.findAllByUserIdAndDeletedFalse(userId, pageable);
+    }
+
+    public Plan getPlan(ObjectId id) {
+        return planRepository.findById(id)
+                .filter(plan -> !plan.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.PLAN_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 이슈 티켓
- [[USER] 웨이팅/예약 상세 API 추가](https://www.notion.so/benkang/USER-API-25e83feabad3807e9dcec48fb55f57d9?v=1ca83feabad3803eba48000c3c30e0e5&source=copy_link)

## 주요 변경 사항
- 플랜 상세 조회 API 추가
- 가게 웨이팅 응답 구조 변경
  - 호출 번호 추가
  - 등록 일시 추가