### PR TITLE
[BE-289] 리워드 메시지 notification 템플릿 방식으로 전환

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -1,6 +1,7 @@
 package im.fooding.app.service.user.notification;
 
 import im.fooding.app.dto.response.user.notification.UserNotificationResponse;
+import im.fooding.core.event.reward.RewardEarnEvent;
 import im.fooding.core.event.waiting.StoreWaitingRegisteredEvent;
 import im.fooding.core.global.infra.slack.SlackClient;
 import im.fooding.core.global.kafka.KafkaEventHandler;
@@ -137,13 +138,14 @@ public class UserNotificationApplicationService {
         return UserNotificationResponse.from(userNotificationService.getNotification(userId, notificationId));
     }
 
-    public void sendRewardEarnMessage(String phoneNumber, String storeName, int point) {
+    @KafkaEventHandler(RewardEarnEvent.class)
+    public void sendRewardEarnMessage(RewardEarnEvent event) {
         NotificationTemplate template = notificationTemplateService.getByType(Type.RewardEarnSms);
 
         String subject = template.getSubject();
         String content = template.getContent().formatted(
-                storeName,
-                point
+                event.storeName(),
+                event.point()
         );
         String message = RewardMessageBuilder.buildMessage(subject, content);
         slackClient.sendNotificationMessage(message);

--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -7,14 +7,13 @@ import im.fooding.core.global.kafka.KafkaEventHandler;
 import im.fooding.core.global.util.RewardMessageBuilder;
 import im.fooding.core.global.util.WaitingMessageBuilder;
 import im.fooding.core.model.notification.NotificationTemplate;
+import im.fooding.core.model.notification.NotificationTemplate.Type;
 import im.fooding.core.model.notification.UserNotification;
 import im.fooding.core.model.waiting.StoreWaiting;
 import im.fooding.core.model.waiting.WaitingUser;
 import im.fooding.core.service.notification.NotificationTemplateService;
 import im.fooding.core.service.notification.UserNotificationService;
-import im.fooding.core.service.user.UserService;
 import im.fooding.core.service.waiting.StoreWaitingService;
-import im.fooding.core.service.waiting.WaitingUserService;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,9 +34,7 @@ public class UserNotificationApplicationService {
     private final SlackClient slackClient;
     private final UserNotificationService userNotificationService;
     private final NotificationTemplateService notificationTemplateService;
-    private final WaitingUserService waitingUserService;
     private final StoreWaitingService storeWaitingService;
-    private final UserService userService;
 
     @Value("${message.sender}")
     private String SENDER;
@@ -140,10 +137,15 @@ public class UserNotificationApplicationService {
         return UserNotificationResponse.from(userNotificationService.getNotification(userId, notificationId));
     }
 
-    public void sendRewardRegisterMessage( String storeName, int point ) {
-        String message = RewardMessageBuilder.buildRegisterMessage(
+    public void sendRewardEarnMessage(String phoneNumber, String storeName, int point) {
+        NotificationTemplate template = notificationTemplateService.getByType(Type.RewardEarnSms);
+
+        String subject = template.getSubject();
+        String content = template.getContent().formatted(
                 storeName,
-                point );
+                point
+        );
+        String message = RewardMessageBuilder.buildMessage(subject, content);
         slackClient.sendNotificationMessage(message);
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/reward/RewardApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/reward/RewardApplicationService.java
@@ -17,8 +17,6 @@ import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.coupon.UserCoupon;
 import im.fooding.core.model.notification.NotificationChannel;
-import im.fooding.core.model.reward.RewardLog;
-import im.fooding.core.model.reward.RewardPoint;
 import im.fooding.core.model.reward.RewardStatus;
 import im.fooding.core.model.user.User;
 import im.fooding.core.service.coupon.UserCouponService;
@@ -116,7 +114,7 @@ public class RewardApplicationService {
                 request.getType(),
                 request.getChannel()
         );
-        sendNotification( request.getStoreId(), request.getPoint() );
+        sendNotification(request.getPhoneNumber(), request.getStoreId(), request.getPoint());
     }
 
     /**
@@ -159,8 +157,8 @@ public class RewardApplicationService {
         publisher.publishEvent(new RequestCouponEvent(userCoupon.getName(), userCoupon.getUser().getPhoneNumber(), SENDER, NotificationChannel.SMS));
     }
 
-    private void sendNotification(long storeId, int point) {
-        String storeName = storeService.findById( storeId ).getName();
-        notificationService.sendRewardRegisterMessage( storeName, point );
+    private void sendNotification(String phoneNumber, long storeId, int point) {
+        String storeName = storeService.findById(storeId).getName();
+        notificationService.sendRewardEarnMessage(phoneNumber, storeName, point);
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/reward/RewardApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/reward/RewardApplicationService.java
@@ -9,12 +9,13 @@ import im.fooding.app.dto.request.user.reward.UpdateRewardPointRequest;
 import im.fooding.app.dto.response.app.coupon.AppUserCouponResponse;
 import im.fooding.app.dto.response.user.reward.GetRewardLogResponse;
 import im.fooding.app.dto.response.user.reward.GetRewardPointResponse;
-import im.fooding.app.service.user.notification.UserNotificationApplicationService;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.event.coupon.RequestCouponEvent;
+import im.fooding.core.event.reward.RewardEarnEvent;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.global.kafka.EventProducerService;
 import im.fooding.core.model.coupon.UserCoupon;
 import im.fooding.core.model.notification.NotificationChannel;
 import im.fooding.core.model.reward.RewardStatus;
@@ -45,7 +46,7 @@ public class RewardApplicationService {
     private final UserService userService;
     private final UserCouponService userCouponService;
     private final ApplicationEventPublisher publisher;
-    private final UserNotificationApplicationService notificationService;
+    private final EventProducerService eventProducerService;
 
     @Value("${message.sender}")
     private String SENDER;
@@ -159,6 +160,10 @@ public class RewardApplicationService {
 
     private void sendNotification(String phoneNumber, long storeId, int point) {
         String storeName = storeService.findById(storeId).getName();
-        notificationService.sendRewardEarnMessage(phoneNumber, storeName, point);
+
+        eventProducerService.publishEvent(
+                RewardEarnEvent.class.getSimpleName(),
+                new RewardEarnEvent(phoneNumber, storeName, point)
+        );
     }
 }

--- a/fooding-api/src/main/java/im/fooding/core/event/reward/RewardEarnEvent.java
+++ b/fooding-api/src/main/java/im/fooding/core/event/reward/RewardEarnEvent.java
@@ -1,0 +1,8 @@
+package im.fooding.core.event.reward;
+
+public record RewardEarnEvent(
+        String phoneNumber,
+        String storeName,
+        int point
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/util/RewardMessageBuilder.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/util/RewardMessageBuilder.java
@@ -1,18 +1,13 @@
 package im.fooding.core.global.util;
 
 public class RewardMessageBuilder {
-    public static String buildRegisterMessage( String storeName, int point ){
+
+    public static String buildMessage(String subject, String content) {
         return """
                 title
-                푸딩 리워드 적립 완료
-                
+                %s
                 boty
-                [푸딩]
-                축하드립니다! %d포인트가 적립되었어요 🎁
-                포인트는 푸딩에서 회원가입 후 사용하실 수 있어요.
-                푸딩과 함께 알뜰한 소비 시작해볼까요?
-                                
-                https://fooding.im/
-                """.formatted( point );
+                %s
+                """.formatted(subject, content);
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
@@ -26,6 +26,7 @@ public class NotificationTemplate extends BaseDocument {
     public enum Type {
         WaitingCreatedEmail,
         WaitingCreatedSms,
+        RewardEarnSms
     }
 
     public NotificationTemplate(Type type, String subject, String content) {


### PR DESCRIPTION
## 이슈 티켓
- [리워드 메시지 notification 템플릿 방식으로 전환](https://www.notion.so/benkang/notification-25383feabad38000aaebcf5ea4efd46e?source=copy_link)

## 주요 변경 사항
- 리워드 적립 메세지 notificationTemplate 방식으로 변경
- 리워드 적립 메세지 카프카 pub/sub 구조로 변경

## 메모
- 리워드 적립 메세지 데이터
  ```json
  {
    "type": "RewardEarnSms",
    "subject": "푸딩 리워드 적립 완료",
    "content": "[푸딩]\n축하드립니다! %s에 %d포인트가 적립되었어요 🎁\n포인트는 푸딩에서 회원가입 후 사용하실 수 있어요.\n푸딩과 함께 알뜰한 소비 시작해볼까요?\nhttps://fooding.im/"
  }
  ```