### PR TITLE
[BE-324] [USER, BO] 배너 CURD API

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/banner/AdminBannerController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/banner/AdminBannerController.java
@@ -1,0 +1,77 @@
+package im.fooding.app.controller.admin.banner;
+
+
+import im.fooding.app.dto.request.admin.banner.AdminBannerCreateRequest;
+import im.fooding.app.dto.request.admin.banner.AdminBannerPageRequest;
+import im.fooding.app.dto.request.admin.banner.AdminBannerUpdateRequest;
+import im.fooding.app.dto.response.admin.banner.AdminBannerResponse;
+import im.fooding.app.service.admin.banner.AdminBannerService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.global.UserInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/banners")
+@Tag(name = "AdminBannerController", description = "Admin Banner Controller")
+public class AdminBannerController {
+
+    private final AdminBannerService adminBannerService;
+
+    @PostMapping
+    @Operation(summary = "배너 생성")
+    public ApiResult<String> createBanner(
+            @RequestBody @Valid AdminBannerCreateRequest request
+    ) {
+        return ApiResult.ok(adminBannerService.createBanner(request));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "배너 조회")
+    public ApiResult<AdminBannerResponse> getBanner(
+            @PathVariable String id
+    ) {
+        return ApiResult.ok(adminBannerService.getBanner(id));
+    }
+
+    @GetMapping
+    @Operation(summary = "배너 조회(page)")
+    public ApiResult<PageResponse<AdminBannerResponse>> getBanners(
+            @Valid AdminBannerPageRequest request
+    ) {
+        return ApiResult.ok(adminBannerService.getBanners(request));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "배너 수정")
+    public ApiResult<Void> updateBanner(
+            @PathVariable String id,
+            @RequestBody @Valid AdminBannerUpdateRequest request
+    ) {
+        adminBannerService.updateBanner(id, request);
+        return ApiResult.ok();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "배너 제거")
+    public ApiResult<Void> deleteBanner(
+            @PathVariable String id,
+            @AuthenticationPrincipal UserInfo userInfo
+    ) {
+        adminBannerService.deleteBanner(id, userInfo.getId());
+        return ApiResult.ok();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/user/banner/UserBannerController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/user/banner/UserBannerController.java
@@ -1,0 +1,41 @@
+package im.fooding.app.controller.user.banner;
+
+
+import im.fooding.app.dto.request.user.banner.UserBannerPageRequest;
+import im.fooding.app.dto.response.user.banner.UserBannerResponse;
+import im.fooding.app.service.user.banner.UserBannerService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/banners")
+@Tag(name = "UserBannerController", description = "User Banner Controller")
+public class UserBannerController {
+
+    private final UserBannerService userBannerService;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "배너 조회")
+    public ApiResult<UserBannerResponse> getBanner(
+            @PathVariable String id
+    ) {
+        return ApiResult.ok(userBannerService.getBanner(id));
+    }
+
+    @GetMapping
+    @Operation(summary = "배너 조회(page)")
+    public ApiResult<PageResponse<UserBannerResponse>> getBanners(
+            @Valid UserBannerPageRequest request
+    ) {
+        return ApiResult.ok(userBannerService.getBanners(request));
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerCreateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerCreateRequest.java
@@ -19,7 +19,7 @@ public class AdminBannerCreateRequest {
 
     @Schema(description = "활성화 상태", example = "true")
     @NotNull
-    Boolean isActive;
+    Boolean active;
 
     @Schema(description = "우선 순위", example = "0")
     @NotNull

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerCreateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerCreateRequest.java
@@ -1,0 +1,34 @@
+package im.fooding.app.dto.request.admin.banner;
+
+import im.fooding.core.model.banner.Banner;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Value;
+
+@Value
+public class AdminBannerCreateRequest {
+
+    @Schema(description = "이름", example = "흑백요리사 출연 셰프 맛집 예약")
+    @NotBlank
+    String name;
+
+    @Schema(description = "설명", example = "흑백요리사 출연 셰프 맛집 예약을 바로할 수 있는 링크로 연결되는 배너")
+    @NotNull
+    String description;
+
+    @Schema(description = "활성화 상태", example = "true")
+    @NotNull
+    Boolean isActive;
+
+    @Schema(description = "우선 순위", example = "0")
+    @NotNull
+    Integer priority;
+
+    @Schema(description = "링크", example = "https://fooding.im/")
+    String link;
+
+    @Schema(description = "링크 종류", example = "INTERNAL")
+    @NotNull
+    Banner.LinkType linkType;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerPageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerPageRequest.java
@@ -1,0 +1,6 @@
+package im.fooding.app.dto.request.admin.banner;
+
+import im.fooding.core.common.BasicSearch;
+
+public class AdminBannerPageRequest extends BasicSearch {
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerUpdateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerUpdateRequest.java
@@ -1,0 +1,34 @@
+package im.fooding.app.dto.request.admin.banner;
+
+import im.fooding.core.model.banner.Banner;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Value;
+
+@Value
+public class AdminBannerUpdateRequest {
+
+    @Schema(description = "이름", example = "흑백요리사 출연 셰프 맛집 예약")
+    @NotBlank
+    String name;
+
+    @Schema(description = "설명", example = "흑백요리사 출연 셰프 맛집 예약을 바로할 수 있는 링크로 연결되는 배너")
+    @NotNull
+    String description;
+
+    @Schema(description = "활성화 상태", example = "true")
+    @NotNull
+    Boolean isActive;
+
+    @Schema(description = "우선 순위", example = "0")
+    @NotNull
+    Integer priority;
+
+    @Schema(description = "링크", example = "https://fooding.im/")
+    String link;
+
+    @Schema(description = "링크 종류", example = "INTERNAL")
+    @NotNull
+    Banner.LinkType linkType;
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerUpdateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/banner/AdminBannerUpdateRequest.java
@@ -19,7 +19,7 @@ public class AdminBannerUpdateRequest {
 
     @Schema(description = "활성화 상태", example = "true")
     @NotNull
-    Boolean isActive;
+    Boolean active;
 
     @Schema(description = "우선 순위", example = "0")
     @NotNull

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/banner/UserBannerPageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/banner/UserBannerPageRequest.java
@@ -1,0 +1,6 @@
+package im.fooding.app.dto.request.user.banner;
+
+import im.fooding.core.common.BasicSearch;
+
+public class UserBannerPageRequest extends BasicSearch {
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/admin/banner/AdminBannerResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/admin/banner/AdminBannerResponse.java
@@ -22,7 +22,7 @@ public class AdminBannerResponse {
     String description;
 
     @Schema(description = "활성화 상태", requiredMode = REQUIRED, example = "true")
-    Boolean isActive;
+    Boolean active;
 
     @Schema(description = "우선 순위", requiredMode = REQUIRED, example = "0")
     Integer priority;
@@ -38,7 +38,7 @@ public class AdminBannerResponse {
                 .id(banner.getId().toString())
                 .name(banner.getName())
                 .description(banner.getDescription())
-                .isActive(banner.isActive())
+                .active(banner.isActive())
                 .priority(banner.getPriority())
                 .link(banner.getLink())
                 .linkType(banner.getLinkType())

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/admin/banner/AdminBannerResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/admin/banner/AdminBannerResponse.java
@@ -1,0 +1,47 @@
+package im.fooding.app.dto.response.admin.banner;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import im.fooding.core.model.banner.Banner;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class AdminBannerResponse {
+
+    @Schema(description = "ID", requiredMode = REQUIRED, example = "6889bf12db34d469470f868e")
+    String id;
+
+    @Schema(description = "이름", requiredMode = REQUIRED, example = "흑백요리사 출연 셰프 맛집 예약")
+    String name;
+
+    @Schema(description = "설명", requiredMode = REQUIRED, example = "흑백요리사 출연 셰프 맛집 예약을 바로할 수 있는 링크로 연결되는 배너")
+    String description;
+
+    @Schema(description = "활성화 상태", requiredMode = REQUIRED, example = "true")
+    Boolean isActive;
+
+    @Schema(description = "우선 순위", requiredMode = REQUIRED, example = "0")
+    Integer priority;
+
+    @Schema(description = "링크", requiredMode = NOT_REQUIRED, example = "https://fooding.im/")
+    String link;
+
+    @Schema(description = "링크 종류", requiredMode = REQUIRED, example = "INTERNAL")
+    Banner.LinkType linkType;
+
+    public static AdminBannerResponse from(Banner banner) {
+        return AdminBannerResponse.builder()
+                .id(banner.getId().toString())
+                .name(banner.getName())
+                .description(banner.getDescription())
+                .isActive(banner.isActive())
+                .priority(banner.getPriority())
+                .link(banner.getLink())
+                .linkType(banner.getLinkType())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/banner/UserBannerResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/banner/UserBannerResponse.java
@@ -1,0 +1,47 @@
+package im.fooding.app.dto.response.user.banner;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import im.fooding.core.model.banner.Banner;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class UserBannerResponse {
+
+    @Schema(description = "ID", requiredMode = REQUIRED, example = "6889bf12db34d469470f868e")
+    String id;
+
+    @Schema(description = "이름", requiredMode = REQUIRED, example = "흑백요리사 출연 셰프 맛집 예약")
+    String name;
+
+    @Schema(description = "설명", requiredMode = REQUIRED, example = "흑백요리사 출연 셰프 맛집 예약을 바로할 수 있는 링크로 연결되는 배너")
+    String description;
+
+    @Schema(description = "활성화 상태", requiredMode = REQUIRED, example = "true")
+    Boolean isActive;
+
+    @Schema(description = "우선 순위", requiredMode = REQUIRED, example = "0")
+    Integer priority;
+
+    @Schema(description = "링크", requiredMode = NOT_REQUIRED, example = "https://fooding.im/")
+    String link;
+
+    @Schema(description = "링크 종류", requiredMode = REQUIRED, example = "INTERNAL")
+    Banner.LinkType linkType;
+
+    public static UserBannerResponse from(Banner banner) {
+        return UserBannerResponse.builder()
+                .id(banner.getId().toString())
+                .name(banner.getName())
+                .description(banner.getDescription())
+                .isActive(banner.isActive())
+                .priority(banner.getPriority())
+                .link(banner.getLink())
+                .linkType(banner.getLinkType())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/banner/UserBannerResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/banner/UserBannerResponse.java
@@ -22,7 +22,7 @@ public class UserBannerResponse {
     String description;
 
     @Schema(description = "활성화 상태", requiredMode = REQUIRED, example = "true")
-    Boolean isActive;
+    Boolean active;
 
     @Schema(description = "우선 순위", requiredMode = REQUIRED, example = "0")
     Integer priority;
@@ -38,7 +38,7 @@ public class UserBannerResponse {
                 .id(banner.getId().toString())
                 .name(banner.getName())
                 .description(banner.getDescription())
-                .isActive(banner.isActive())
+                .active(banner.isActive())
                 .priority(banner.getPriority())
                 .link(banner.getLink())
                 .linkType(banner.getLinkType())

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/banner/AdminBannerService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/banner/AdminBannerService.java
@@ -26,7 +26,7 @@ public class AdminBannerService {
          return bannerService.createBanner(
                  request.getName(),
                  request.getDescription(),
-                 request.getIsActive(),
+                 request.getActive(),
                  request.getPriority(),
                  request.getLink(),
                  request.getLinkType()
@@ -51,7 +51,7 @@ public class AdminBannerService {
                 new ObjectId(id),
                 request.getName(),
                 request.getDescription(),
-                request.getIsActive(),
+                request.getActive(),
                 request.getPriority(),
                 request.getLink(),
                 request.getLinkType()

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/banner/AdminBannerService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/banner/AdminBannerService.java
@@ -1,0 +1,65 @@
+package im.fooding.app.service.admin.banner;
+
+import im.fooding.app.dto.request.admin.banner.AdminBannerCreateRequest;
+import im.fooding.app.dto.request.admin.banner.AdminBannerUpdateRequest;
+import im.fooding.app.dto.request.admin.banner.AdminBannerPageRequest;
+import im.fooding.app.dto.response.admin.banner.AdminBannerResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.banner.Banner;
+import im.fooding.core.service.banner.BannerService;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminBannerService {
+
+    private final BannerService bannerService;
+
+    @Transactional
+    public String createBanner(AdminBannerCreateRequest request) {
+         return bannerService.createBanner(
+                 request.getName(),
+                 request.getDescription(),
+                 request.getIsActive(),
+                 request.getPriority(),
+                 request.getLink(),
+                 request.getLinkType()
+         ).toString();
+    }
+
+    public AdminBannerResponse getBanner(String id) {
+        return AdminBannerResponse.from(bannerService.getBanner(new ObjectId(id)));
+    }
+
+    public PageResponse<AdminBannerResponse> getBanners(AdminBannerPageRequest request) {
+        Page<Banner> banners = bannerService.getBanners(request.getPageable());
+        return PageResponse.of(
+                banners.map(AdminBannerResponse::from).toList(),
+                PageInfo.of(banners)
+        );
+    }
+
+    @Transactional
+    public void updateBanner(String id, AdminBannerUpdateRequest request) {
+        bannerService.updateBanner(
+                new ObjectId(id),
+                request.getName(),
+                request.getDescription(),
+                request.getIsActive(),
+                request.getPriority(),
+                request.getLink(),
+                request.getLinkType()
+        );
+    }
+
+    @Transactional
+    public void deleteBanner(String id, long deletedBy) {
+        bannerService.deleteBanner(new ObjectId(id), deletedBy);
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/user/banner/UserBannerService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/banner/UserBannerService.java
@@ -20,7 +20,7 @@ public class UserBannerService {
     private final BannerService bannerService;
 
     public UserBannerResponse getBanner(String id) {
-        return UserBannerResponse.from(bannerService.getBanner(new ObjectId(id)));
+        return UserBannerResponse.from(bannerService.getActiveBanner(new ObjectId(id)));
     }
 
     public PageResponse<UserBannerResponse> getBanners(UserBannerPageRequest request) {

--- a/fooding-api/src/main/java/im/fooding/app/service/user/banner/UserBannerService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/banner/UserBannerService.java
@@ -1,0 +1,33 @@
+package im.fooding.app.service.user.banner;
+
+import im.fooding.app.dto.request.user.banner.UserBannerPageRequest;
+import im.fooding.app.dto.response.user.banner.UserBannerResponse;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.model.banner.Banner;
+import im.fooding.core.service.banner.BannerService;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserBannerService {
+
+    private final BannerService bannerService;
+
+    public UserBannerResponse getBanner(String id) {
+        return UserBannerResponse.from(bannerService.getBanner(new ObjectId(id)));
+    }
+
+    public PageResponse<UserBannerResponse> getBanners(UserBannerPageRequest request) {
+        Page<Banner> banners = bannerService.getActiveBanners(request.getPageable());
+        return PageResponse.of(
+                banners.map(UserBannerResponse::from).toList(),
+                PageInfo.of(banners)
+        );
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -122,6 +122,9 @@ public enum ErrorCode {
 
     // 예약/웨이팅
     PLAN_NOT_FOUND(HttpStatus.BAD_REQUEST, "12000", "등록된 예약/웨이팅이 없습니다."),
+
+    // 배너
+    BANNER_NOT_FOUND(HttpStatus.BAD_REQUEST, "13000", "등록된 배너가 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -125,6 +125,7 @@ public enum ErrorCode {
 
     // 배너
     BANNER_NOT_FOUND(HttpStatus.BAD_REQUEST, "13000", "등록된 배너가 없습니다."),
+    BANNER_INACTIVE(HttpStatus.BAD_REQUEST, "13001", "비활성화된 배너입니다."),
     ;
 
     private final HttpStatus status;

--- a/fooding-core/src/main/java/im/fooding/core/model/banner/Banner.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/banner/Banner.java
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Document(collection = "plan")
+@Document(collection = "banner")
 public class Banner extends BaseDocument {
 
     @Id

--- a/fooding-core/src/main/java/im/fooding/core/model/banner/Banner.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/banner/Banner.java
@@ -21,7 +21,7 @@ public class Banner extends BaseDocument {
 
     private String description;
 
-    private boolean isActive = false;
+    private boolean active = false;
 
     private int priority;
 
@@ -53,14 +53,14 @@ public class Banner extends BaseDocument {
     public Banner(
             String name,
             String description,
-            boolean isActive,
+            boolean active,
             int priority,
             String link,
             LinkType linkType
     ) {
         this.name = name;
         this.description = description;
-        this.isActive = isActive;
+        this.active = active;
         this.priority = priority;
         this.link = link;
         this.linkType = linkType;
@@ -69,14 +69,14 @@ public class Banner extends BaseDocument {
     public void update(
             String name,
             String description,
-            boolean isActive,
+            boolean active,
             int priority,
             String link,
             LinkType linkType
     ) {
         this.name = name;
         this.description = description;
-        this.isActive = isActive;
+        this.active = active;
         this.priority = priority;
         this.link = link;
         this.linkType = linkType;

--- a/fooding-core/src/main/java/im/fooding/core/model/banner/Banner.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/banner/Banner.java
@@ -1,0 +1,84 @@
+package im.fooding.core.model.banner;
+
+import im.fooding.core.model.BaseDocument;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "plan")
+public class Banner extends BaseDocument {
+
+    @Id
+    private ObjectId id;
+
+    private String name;
+
+    private String description;
+
+    private boolean isActive = false;
+
+    private int priority;
+
+    private String link;
+
+    private LinkType linkType;
+
+    public enum Type {
+        MAIN,
+    }
+
+    public enum LinkType {
+        INTERNAL,       // 같은 사이트 내 페이지 이동
+        EXTERNAL,       // 외부 사이트로 이동 (새창)
+        // 특수 동작
+        MODAL,          // 모달/팝업 열기
+        DOWNLOAD,       // 파일 다운로드
+        NONE,           // 클릭 불가 (순수 이미지)
+        // 딥링크/앱 관련
+        DEEPLINK,       // 앱 딥링크
+        APP_STORE,      // APP_STORE 이동
+        // 기능적 링크
+        PHONE,          // 전화걸기
+        EMAIL,          // 이메일
+        SMS,            // SMS 발신
+    }
+
+    @Builder
+    public Banner(
+            String name,
+            String description,
+            boolean isActive,
+            int priority,
+            String link,
+            LinkType linkType
+    ) {
+        this.name = name;
+        this.description = description;
+        this.isActive = isActive;
+        this.priority = priority;
+        this.link = link;
+        this.linkType = linkType;
+    }
+
+    public void update(
+            String name,
+            String description,
+            boolean isActive,
+            int priority,
+            String link,
+            LinkType linkType
+    ) {
+        this.name = name;
+        this.description = description;
+        this.isActive = isActive;
+        this.priority = priority;
+        this.link = link;
+        this.linkType = linkType;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/banner/BannerRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/banner/BannerRepository.java
@@ -11,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface BannerRepository extends MongoRepository<Banner, ObjectId> {
 
     Page<Banner> findAllByDeletedFalse(Pageable pageable);
+
+    Page<Banner> findAllByIsActiveTrueAndDeletedFalse(Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/banner/BannerRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/banner/BannerRepository.java
@@ -12,5 +12,5 @@ public interface BannerRepository extends MongoRepository<Banner, ObjectId> {
 
     Page<Banner> findAllByDeletedFalse(Pageable pageable);
 
-    Page<Banner> findAllByIsActiveTrueAndDeletedFalse(Pageable pageable);
+    Page<Banner> findAllByActiveTrueAndDeletedFalse(Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/banner/BannerRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/banner/BannerRepository.java
@@ -1,0 +1,14 @@
+package im.fooding.core.repository.banner;
+
+import im.fooding.core.model.banner.Banner;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BannerRepository extends MongoRepository<Banner, ObjectId> {
+
+    Page<Banner> findAllByDeletedFalse(Pageable pageable);
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
@@ -1,0 +1,86 @@
+package im.fooding.core.service.banner;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.banner.Banner;
+import im.fooding.core.repository.banner.BannerRepository;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    @Transactional
+    public ObjectId createBanner(
+            String name,
+            String description,
+            boolean isActive,
+            int priority,
+            String link,
+            Banner.LinkType linkType
+    ) {
+        Banner newBanner = Banner.builder()
+                .name(name)
+                .description(description)
+                .isActive(isActive)
+                .priority(priority)
+                .link(link)
+                .linkType(linkType)
+                .build();
+
+        Banner savedBanner = bannerRepository.save(newBanner);
+
+        return savedBanner.getId();
+    }
+
+    public Banner getBanner(ObjectId id) {
+        return bannerRepository.findById(id)
+                .filter(banner -> !banner.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.BANNER_NOT_FOUND));
+    }
+
+    public Page<Banner> getBanners(Pageable pageable) {
+        return bannerRepository.findAllByDeletedFalse(pageable);
+    }
+
+    @Transactional
+    public void updateBanner(
+            ObjectId id,
+            String name,
+            String description,
+            boolean isActive,
+            int priority,
+            String link,
+            Banner.LinkType linkType
+    ) {
+        Banner targetBanner = getBanner(id);
+
+        targetBanner.update(
+                name,
+                description,
+                isActive,
+                priority,
+                link,
+                linkType
+        );
+
+        bannerRepository.save(targetBanner);
+    }
+
+    @Transactional
+    public void deleteBanner(ObjectId id, long deletedBy) {
+        Banner targetBanner = getBanner(id);
+
+        targetBanner.delete(deletedBy);
+
+        bannerRepository.save(targetBanner);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
@@ -30,7 +30,7 @@ public class BannerService {
         Banner newBanner = Banner.builder()
                 .name(name)
                 .description(description)
-                .isActive(active)
+                .active(active)
                 .priority(priority)
                 .link(link)
                 .linkType(linkType)
@@ -52,7 +52,7 @@ public class BannerService {
     }
 
     public Page<Banner> getActiveBanners(Pageable pageable) {
-        return bannerRepository.findAllByIsActiveTrueAndDeletedFalse(pageable);
+        return bannerRepository.findAllByActiveTrueAndDeletedFalse(pageable);
     }
 
     @Transactional
@@ -60,7 +60,7 @@ public class BannerService {
             ObjectId id,
             String name,
             String description,
-            boolean isActive,
+            boolean active,
             int priority,
             String link,
             Banner.LinkType linkType
@@ -70,7 +70,7 @@ public class BannerService {
         targetBanner.update(
                 name,
                 description,
-                isActive,
+                active,
                 priority,
                 link,
                 linkType

--- a/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
@@ -22,7 +22,7 @@ public class BannerService {
     public ObjectId createBanner(
             String name,
             String description,
-            boolean isActive,
+            boolean active,
             int priority,
             String link,
             Banner.LinkType linkType
@@ -30,7 +30,7 @@ public class BannerService {
         Banner newBanner = Banner.builder()
                 .name(name)
                 .description(description)
-                .isActive(isActive)
+                .isActive(active)
                 .priority(priority)
                 .link(link)
                 .linkType(linkType)
@@ -49,6 +49,10 @@ public class BannerService {
 
     public Page<Banner> getBanners(Pageable pageable) {
         return bannerRepository.findAllByDeletedFalse(pageable);
+    }
+
+    public Page<Banner> getActiveBanners(Pageable pageable) {
+        return bannerRepository.findAllByIsActiveTrueAndDeletedFalse(pageable);
     }
 
     @Transactional

--- a/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/banner/BannerService.java
@@ -4,6 +4,7 @@ import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.banner.Banner;
 import im.fooding.core.repository.banner.BannerRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
@@ -45,6 +46,12 @@ public class BannerService {
         return bannerRepository.findById(id)
                 .filter(banner -> !banner.isDeleted())
                 .orElseThrow(() -> new ApiException(ErrorCode.BANNER_NOT_FOUND));
+    }
+
+    public Banner getActiveBanner(ObjectId id) {
+        return Optional.of(getBanner(id))
+                .filter(Banner::isActive)
+                .orElseThrow(() -> new ApiException(ErrorCode.BANNER_INACTIVE));
     }
 
     public Page<Banner> getBanners(Pageable pageable) {


### PR DESCRIPTION
## 이슈 티켓
- [[USER, BO] 배너 CURD API](https://www.notion.so/USER-BO-CURD-API-25f83feabad380bd96eaeafe142c3987?source=copy_link)

## 주요 변경 사항
- 배너 model 생성
- [ADMIN] 배너 CRUD API 생성
- [USER] 배너 READ API 생성
  -  active = true 상태 배너만 조회 가능하도록 코드 작성