### PR TITLE
[BE-330] [CEO] 카테고리 정렬 기능 Swagger example 올바르게 변경

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoSortMenuCategoryRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoSortMenuCategoryRequest.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class CeoSortMenuCategoryRequest {
 
     @NotEmpty
-    @Schema(description = "정렬된 순서로 나열된 메뉴 카테고리 ID", example = "5,3,4,2,1")
+    @Schema(description = "정렬된 순서로 나열된 메뉴 카테고리 ID", example = "[5,3,4,2,1]")
     private List<Long> menuCategoryIds;
 
 }


### PR DESCRIPTION
## 이슈
- [[CEO] 카테고리 정렬 기능 Swagger example 올바르게 변경](https://www.notion.so/benkang/CEO-Swagger-example-26483feabad38029acfcd5e96b823a85?source=copy_link)

## 내용
- `List<Long>` 요청에 대해 swagger example 변경
  - 변경 전: `5,3,4,2,1`
  - 변경 후: `[5,3,4,2,1]`