### PR TITLE
[BE-333] plans list 조회 queryDSL 방식으로 변경

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/plan/UserPlanRetrieveRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/plan/UserPlanRetrieveRequest.java
@@ -1,6 +1,8 @@
 package im.fooding.app.dto.request.user.plan;
 
 import im.fooding.core.common.BasicSearch;
+import im.fooding.core.model.plan.Plan;
+import im.fooding.core.model.plan.Plan.VisitStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +13,4 @@ public class UserPlanRetrieveRequest extends BasicSearch {
 
     @Schema(description = "방문 상태 (SCHEDULED, COMPLETED, NOT_VISITED)", requiredMode = RequiredMode.REQUIRED, example = "SCHEDULED")
     VisitStatus visitStatus;
-
-    @RequiredArgsConstructor
-    public enum VisitStatus {
-        SCHEDULED,      // 방문예정
-        COMPLETED,      // 방문완료
-        NOT_VISITED,    // 취소/노쇼
-        ;
-    }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/plan/UserPlanService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/plan/UserPlanService.java
@@ -7,6 +7,7 @@ import im.fooding.core.common.PageResponse;
 import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.plan.Plan;
+import im.fooding.core.repository.plan.PlanFilter;
 import im.fooding.core.service.plan.PlanService;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
@@ -20,7 +21,11 @@ public class UserPlanService {
     private final PlanService planService;
 
     public PageResponse<UserPlanResponse> list(UserPlanRetrieveRequest request, Long userId) {
-        Page<Plan> plans = planService.list(userId, request.getPageable());
+        PlanFilter filter = PlanFilter.builder()
+                .userId(userId)
+                .visitStatus(request.getVisitStatus())
+                .build();
+        Page<Plan> plans = planService.list(filter, request.getPageable());
         Page<UserPlanResponse> planResponses = plans.map(UserPlanResponse::from);
 
         return PageResponse.of(planResponses.toList(), PageInfo.of(planResponses));

--- a/fooding-core/src/main/java/im/fooding/core/model/plan/Plan.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/plan/Plan.java
@@ -1,5 +1,6 @@
 package im.fooding.core.model.plan;
 
+import com.querydsl.core.annotations.QueryEntity;
 import im.fooding.core.model.BaseDocument;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -13,6 +14,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "plan")
+@QueryEntity
 public class Plan extends BaseDocument {
 
     @Id

--- a/fooding-core/src/main/java/im/fooding/core/repository/plan/PlanFilter.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/plan/PlanFilter.java
@@ -1,0 +1,15 @@
+package im.fooding.core.repository.plan;
+
+import im.fooding.core.model.plan.Plan.VisitStatus;
+import lombok.Builder;
+
+@Builder
+public record PlanFilter(
+        Long userId,
+        VisitStatus visitStatus
+) {
+
+    public static PlanFilter non() {
+        return new PlanFilter(null, null);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/plan/PlanRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/plan/PlanRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface PlanRepository extends MongoRepository<Plan, ObjectId> {
+public interface PlanRepository extends MongoRepository<Plan, ObjectId>, QPlanRepository {
 
     Page<Plan> findAllByUserIdAndDeletedFalse(long userId, Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/plan/QPlanRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/plan/QPlanRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.plan;
+
+import im.fooding.core.model.plan.Plan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QPlanRepository {
+
+    Page<Plan> list(Pageable pageable);
+
+    Page<Plan> list(PlanFilter filter, Pageable pageable);
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/plan/QPlanRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/plan/QPlanRepositoryImpl.java
@@ -1,0 +1,50 @@
+package im.fooding.core.repository.plan;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import im.fooding.core.model.plan.Plan;
+import im.fooding.core.model.plan.QPlan;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.support.SpringDataMongodbQuery;
+
+@RequiredArgsConstructor
+public class QPlanRepositoryImpl implements QPlanRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Page<Plan> list(Pageable pageable) {
+        return list(PlanFilter.non(), pageable);
+    }
+
+    @Override
+    public Page<Plan> list(PlanFilter filter, Pageable pageable) {
+        QPlan plan = QPlan.plan;
+
+
+        // 조건 생성
+        BooleanExpression condition = plan.deleted.isFalse();
+        if (filter.userId() != null) {
+            condition = condition.and(plan.userId.eq(filter.userId()));
+        }
+        if (filter.visitStatus() != null) {
+            condition = condition.and(plan.visitStatus.eq(filter.visitStatus()));
+        }
+
+        SpringDataMongodbQuery<Plan> query = new SpringDataMongodbQuery<>(mongoTemplate, Plan.class);
+        query = query.where(condition);
+
+        long total = query.fetchCount();
+        query = query.offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        // 결과 조회
+        List<Plan> content = query.fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/plan/PlanService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/plan/PlanService.java
@@ -6,6 +6,7 @@ import im.fooding.core.model.plan.Plan;
 import im.fooding.core.model.plan.Plan.ReservationType;
 import im.fooding.core.model.plan.Plan.VisitStatus;
 import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.repository.plan.PlanFilter;
 import im.fooding.core.repository.plan.PlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
@@ -49,8 +50,8 @@ public class PlanService {
         return planRepository.save(plan).getId();
     }
 
-    public Page<Plan> list(Long userId, Pageable pageable) {
-        return planRepository.findAllByUserIdAndDeletedFalse(userId, pageable);
+    public Page<Plan> list(PlanFilter filter, Pageable pageable) {
+        return planRepository.list(filter, pageable);
     }
 
     public Plan getPlan(ObjectId id) {


### PR DESCRIPTION
## 이슈
- [plans list 조회 queryDSL 방식으로 변경](https://www.notion.so/benkang/plans-list-queryDSL-26783feabad380d18878eeccc3c0ddbf?source=copy_link)

## 내용
- plan 도메인도 banner 처럼 queryDSL 방식으로 변경

## 메모
- 추가적으로 적용되지 않았던 필터 기능도 적용