### PR TITLE
[BE-353] 스토어 이미지 태그 및 대표이미지 API 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/stores/AdminStoreImageController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/stores/AdminStoreImageController.java
@@ -59,4 +59,11 @@ public class AdminStoreImageController {
         service.delete(id);
         return ApiResult.ok();
     }
+
+    @PutMapping("/images/{id}/main")
+    @Operation(summary = "가게 이미지 대표이미지 설정")
+    public ApiResult<Void> updateMain(@PathVariable Long id) {
+        service.updateMain(id);
+        return ApiResult.ok();
+    }
 }

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/stores/CeoStoreImageController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/stores/CeoStoreImageController.java
@@ -51,4 +51,12 @@ public class CeoStoreImageController {
         service.delete(storeId, id, userInfo.getId());
         return ApiResult.ok();
     }
+
+    @PutMapping("/{storeId}/images/{id}/main")
+    @Operation(summary = "대표사진 설정")
+    public ApiResult<Void> updateMain(@PathVariable long storeId, @PathVariable long id,
+                                      @AuthenticationPrincipal UserInfo userInfo) {
+        service.updateMain(storeId, id, userInfo.getId());
+        return ApiResult.ok();
+    }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreImageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminCreateStoreImageRequest.java
@@ -1,5 +1,6 @@
 package im.fooding.app.dto.request.admin.store;
 
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -7,6 +8,8 @@ import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -25,7 +28,7 @@ public class AdminCreateStoreImageRequest {
     @NotNull(message = "정렬순서는 필수입니다.")
     private Integer sortOrder;
 
-    @Schema(description = "태그", example = "업체,음식")
-    private String tags;
+    @Schema(description = "태그", example = "[\"PRICE_TAG\", \"FOOD\", \"BEVERAGE\", \"INTERIOR\", \"EXTERIOR\"]")
+    private List<StoreImageTag> tags;
 }
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminSearchStoreImageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminSearchStoreImageRequest.java
@@ -1,6 +1,7 @@
 package im.fooding.app.dto.request.admin.store;
 
 import im.fooding.core.common.BasicSearch;
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +11,13 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class AdminSearchStoreImageRequest extends BasicSearch {
-    @Schema(description = "검색 태그", example = "업체")
-    private String searchTag;
+    @Schema(description = "검색 태그", example = "PRICE_TAG")
+    private StoreImageTag tag;
     
     @Schema(description = "스토어 ID", example = "1")
     private Long storeId;
+
+    @Schema(description = "대표사진 여부", example = "true")
+    private Boolean isMain;
 }
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreImageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/store/AdminUpdateStoreImageRequest.java
@@ -1,11 +1,14 @@
 package im.fooding.app.dto.request.admin.store;
 
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -19,7 +22,7 @@ public class AdminUpdateStoreImageRequest {
     @NotNull(message = "정렬순서는 필수입니다.")
     private Integer sortOrder;
 
-    @Schema(description = "태그", example = "업체,음식")
-    private String tags;
+    @Schema(description = "태그", example = "[\"PRICE_TAG\", \"FOOD\", \"BEVERAGE\", \"INTERIOR\", \"EXTERIOR\"]")
+    private List<StoreImageTag> tags;
 }
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/image/CeoCreateStoreImageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/image/CeoCreateStoreImageRequest.java
@@ -1,9 +1,12 @@
 package im.fooding.app.dto.request.ceo.store.image;
 
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -15,6 +18,6 @@ public class CeoCreateStoreImageRequest {
     @Schema(description = "정렬 순서", example = "1")
     private int sortOrder;
 
-    @Schema(description = "태그", example = "업체,음식")
-    private String tags;
+    @Schema(description = "태그", example = "[\"PRICE_TAG\", \"FOOD\", \"BEVERAGE\", \"INTERIOR\", \"EXTERIOR\"]")
+    private List<StoreImageTag> tags;
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/image/CeoSearchStoreImageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/image/CeoSearchStoreImageRequest.java
@@ -1,15 +1,21 @@
 package im.fooding.app.dto.request.ceo.store.image;
 
 import im.fooding.core.common.BasicSearch;
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
 public class CeoSearchStoreImageRequest extends BasicSearch {
-    @Schema(description = "검색 태그", example = "업체")
-    private String searchTag;
+    @Schema(description = "태그", example = "PRICE_TAG")
+    private StoreImageTag tag;
+
+    @Schema(description = "대표사진 여부", example = "true")
+    private Boolean isMain;
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/image/CeoUpdateStoreImageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/store/image/CeoUpdateStoreImageRequest.java
@@ -1,8 +1,11 @@
 package im.fooding.app.dto.request.ceo.store.image;
 
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -13,6 +16,6 @@ public class CeoUpdateStoreImageRequest {
     @Schema(description = "정렬 순서", example = "1")
     private int sortOrder;
 
-    @Schema(description = "태그", example = "업체,음식")
-    private String tags;
+    @Schema(description = "태그", example = "[\"PRICE_TAG\", \"FOOD\", \"BEVERAGE\", \"INTERIOR\", \"EXTERIOR\"]")
+    private List<StoreImageTag> tags;
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/user/store/UserSearchStoreImageRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/user/store/UserSearchStoreImageRequest.java
@@ -1,6 +1,7 @@
 package im.fooding.app.dto.request.user.store;
 
 import im.fooding.core.common.BasicSearch;
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -11,6 +12,9 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class UserSearchStoreImageRequest extends BasicSearch {
-    @Schema(description = "검색 태그", example = "업체")
-    private String searchTag;
+    @Schema(description = "검색 태그", example = "PRICE_TAG")
+    private StoreImageTag tag;
+
+    @Schema(description = "대표사진 여부", example = "false")
+    private Boolean isMain;
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreImageResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/store/CeoStoreImageResponse.java
@@ -1,11 +1,16 @@
 package im.fooding.app.dto.response.ceo.store;
 
+import im.fooding.core.global.util.Util;
 import im.fooding.core.model.store.StoreImage;
+import im.fooding.core.model.store.StoreImageTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -19,23 +24,34 @@ public class CeoStoreImageResponse {
     @Schema(description = "정렬순서", example = "1", requiredMode = RequiredMode.NOT_REQUIRED)
     private int sortOrder;
 
-    @Schema(description = "태그", example = "업체,음식", requiredMode = RequiredMode.NOT_REQUIRED)
-    private String tags;
+    @Schema(description = "태그", example = "[\"PRICE_TAG\", \"FOOD\", \"BEVERAGE\", \"INTERIOR\", \"EXTERIOR\"]", requiredMode = RequiredMode.NOT_REQUIRED)
+    private List<StoreImageTag> tags;
+
+    @Schema(description = "대표사진 여부", example = "false", requiredMode = RequiredMode.REQUIRED)
+    private Boolean isMain;
 
     @Builder
-    private CeoStoreImageResponse(Long id, String imageUrl, int sortOrder, String tags) {
+    private CeoStoreImageResponse(Long id, String imageUrl, int sortOrder, List<StoreImageTag> tags, boolean isMain) {
         this.id = id;
         this.imageUrl = imageUrl;
         this.sortOrder = sortOrder;
         this.tags = tags;
+        this.isMain = isMain;
     }
 
     public static CeoStoreImageResponse of(StoreImage storeImage) {
+        List<StoreImageTag> tags = null;
+        if (StringUtils.hasText(storeImage.getTags())) {
+            tags = Util.generateStringToList(storeImage.getTags()).stream()
+                    .map(StoreImageTag::valueOf) // 문자열이 enum 이름과 정확히 일치해야 함
+                    .toList();
+        }
         return CeoStoreImageResponse.builder()
                 .id(storeImage.getId())
                 .imageUrl(storeImage.getImageUrl())
                 .sortOrder(storeImage.getSortOrder())
-                .tags(storeImage.getTags())
+                .tags(tags)
+                .isMain(storeImage.isMain())
                 .build();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreListResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreListResponse.java
@@ -64,7 +64,11 @@ public class UserStoreListResponse {
     }
 
     public static UserStoreListResponse of(Store store, Integer estimatedWaitingTime) {
-        String imageUrl = store.getImages() != null ? store.getImages().stream().findFirst().map(StoreImage::getImageUrl).orElse(null) : null;
+        String imageUrl = store.getImages() != null ? store.getImages().stream()
+                .filter(it -> it.isMain() && !it.isDeleted())
+                .findFirst().map(StoreImage::getImageUrl)
+                .orElse(null) : null;
+
         return UserStoreListResponse.builder()
                 .id(store.getId())
                 .category(store.getCategory())

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreResponse.java
@@ -97,6 +97,7 @@ public class UserStoreResponse {
 
     public static UserStoreResponse of(Store store, Integer estimatedWaitingTime) {
         List<UserStoreImageResponse> images = store.getImages() != null ? store.getImages().stream()
+                .filter(it -> it.isMain() && !it.isDeleted())
                 .sorted(Comparator.comparing(StoreImage::getSortOrder).thenComparing(Comparator.comparing(StoreImage::getId).reversed()))
                 .map(UserStoreImageResponse::of)
                 .toList() : null;

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreSearchResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/store/UserStoreSearchResponse.java
@@ -72,6 +72,7 @@ public class UserStoreSearchResponse {
 
     public static UserStoreSearchResponse of(Store store, Integer estimatedWaitingTime) {
         List<UserStoreImageResponse> images = store.getImages() != null ? store.getImages().stream()
+                .filter(it -> it.isMain() && !it.isDeleted())
                 .sorted(Comparator.comparing(StoreImage::getSortOrder).thenComparing(Comparator.comparing(StoreImage::getId).reversed()))
                 .map(UserStoreImageResponse::of)
                 .toList() : null;

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreImageService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/store/CeoStoreImageService.java
@@ -7,9 +7,11 @@ import im.fooding.app.dto.response.ceo.store.CeoStoreImageResponse;
 import im.fooding.app.service.file.FileUploadService;
 import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
+import im.fooding.core.global.util.Util;
 import im.fooding.core.model.file.File;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreImage;
+import im.fooding.core.model.store.StoreImageTag;
 import im.fooding.core.service.store.StoreImageService;
 import im.fooding.core.service.store.StoreMemberService;
 import im.fooding.core.service.store.StoreService;
@@ -19,6 +21,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -35,13 +39,13 @@ public class CeoStoreImageService {
         checkMember(store.getId(), userId);
 
         File file = fileUploadService.commit(request.getImageId());
-        return storeImageService.create(store, file.getUrl(), request.getSortOrder(), request.getTags()).getId();
+        return storeImageService.create(store, file.getUrl(), request.getSortOrder(), generateTags(request.getTags())).getId();
     }
 
     @Transactional(readOnly = true)
     public PageResponse<CeoStoreImageResponse> list(long storeId, CeoSearchStoreImageRequest search, long userId) {
         checkMember(storeId, userId);
-        Page<StoreImage> images = storeImageService.list(storeId, search.getSearchTag(), search.getPageable());
+        Page<StoreImage> images = storeImageService.list(storeId, search.getTag(), search.getIsMain(), search.getPageable());
         return PageResponse.of(images.stream().map(CeoStoreImageResponse::of).toList(), PageInfo.of(images));
     }
 
@@ -57,7 +61,7 @@ public class CeoStoreImageService {
             imageUrl = file.getUrl();
         }
 
-        storeImageService.update(storeImage, imageUrl, request.getSortOrder(), request.getTags());
+        storeImageService.update(storeImage, imageUrl, request.getSortOrder(), generateTags(request.getTags()));
     }
 
     @Transactional
@@ -67,7 +71,20 @@ public class CeoStoreImageService {
         storeImageService.delete(storeImage, userId);
     }
 
+    @Transactional
+    public void updateMain(long storeId, long id, long userId) {
+        checkMember(storeId, userId);
+        storeImageService.updateMain(id);
+    }
+
     private void checkMember(long storeId, long userId) {
         storeMemberService.checkMember(storeId, userId);
+    }
+
+    private String generateTags(List<StoreImageTag> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+        return Util.generateListToString(tags.stream().map(StoreImageTag::name).toList());
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStoreImageService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/store/UserStoreImageService.java
@@ -20,7 +20,7 @@ public class UserStoreImageService {
 
     @Transactional(readOnly = true)
     public PageResponse<UserStoreImageResponse> list(long storeId, UserSearchStoreImageRequest search) {
-        Page<StoreImage> images = storeImageService.list(storeId, search.getSearchTag(), search.getPageable());
+        Page<StoreImage> images = storeImageService.list(storeId, search.getTag(), search.getIsMain(), search.getPageable());
         return PageResponse.of(images.stream().map(UserStoreImageResponse::of).toList(), PageInfo.of(images));
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StoreImage.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StoreImage.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.util.StringUtils;
 
@@ -43,6 +44,9 @@ public class StoreImage extends BaseEntity {
 
     private String tags;
 
+    @ColumnDefault("false")
+    private boolean isMain;
+
     @Builder
     private StoreImage(Store store, String imageUrl, int sortOrder, String tags) {
         this.store = store;
@@ -54,6 +58,10 @@ public class StoreImage extends BaseEntity {
     public void update(String imageUrl, int sortOrder, String tags) {
         this.imageUrl = imageUrl;
         this.sortOrder = sortOrder;
-        this.tags = !StringUtils.hasText(tags) ? null : tags;;
+        this.tags = !StringUtils.hasText(tags) ? null : tags;
+    }
+
+    public void updateMain() {
+        this.isMain = !this.isMain;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/model/store/StoreImageTag.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/store/StoreImageTag.java
@@ -1,0 +1,9 @@
+package im.fooding.core.model.store;
+
+public enum StoreImageTag {
+    PRICE_TAG,
+    FOOD,
+    BEVERAGE,
+    INTERIOR,
+    EXTERIOR;
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/QStoreRepositoryImpl.java
@@ -91,7 +91,7 @@ public class QStoreRepositoryImpl implements QStoreRepository {
     public Optional<Store> retrieve(long storeId, Set<StoreStatus> statuses) {
         return Optional.ofNullable(query
                 .selectFrom(store)
-                .leftJoin(store.images, storeImage).fetchJoin()
+                .leftJoin(store.images, storeImage)
                 .where(
                         store.id.eq(storeId),
                         store.deleted.isFalse(),

--- a/fooding-core/src/main/java/im/fooding/core/repository/store/image/QStoreImageRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/store/image/QStoreImageRepository.java
@@ -1,6 +1,7 @@
 package im.fooding.core.repository.store.image;
 
 import im.fooding.core.model.store.StoreImage;
+import im.fooding.core.model.store.StoreImageTag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,5 +11,5 @@ public interface QStoreImageRepository {
 
     Optional<StoreImage> findByStore(Long storeId);
 
-    Page<StoreImage> list(long storeId, String searchTag, Pageable pageable);
+    Page<StoreImage> list(long storeId, StoreImageTag tag, Boolean isMain, Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/store/StoreImageService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/store/StoreImageService.java
@@ -4,6 +4,7 @@ import im.fooding.core.global.exception.ApiException;
 import im.fooding.core.global.exception.ErrorCode;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.model.store.StoreImage;
+import im.fooding.core.model.store.StoreImageTag;
 import im.fooding.core.repository.store.image.StoreImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -68,8 +69,8 @@ public class StoreImageService {
      * @param pageable
      * @return Page<StoreImage>
      */
-    public Page<StoreImage> list(long storeId, String searchTag, Pageable pageable) {
-        return storeImageRepository.list(storeId, searchTag, pageable);
+    public Page<StoreImage> list(long storeId, StoreImageTag tag, Boolean isMain, Pageable pageable) {
+        return storeImageRepository.list(storeId, tag, isMain, pageable);
     }
 
     /**
@@ -92,5 +93,14 @@ public class StoreImageService {
      */
     public void update(StoreImage storeImage, String imageUrl, int sortOrder, String tags) {
         storeImage.update(imageUrl, sortOrder, tags);
+    }
+
+    /**
+     * 대표이미지 설정
+     * @param id
+     */
+    public void updateMain(long id) {
+        StoreImage storeImage = findById(id);
+        storeImage.updateMain();
     }
 }


### PR DESCRIPTION
## 이슈
[BE-353](https://www.notion.so/benkang/CEO-API-27183feabad380f19f71ef2df5df75d1?source=copy_link)

## 내용
- 스토어 이미지 태그 enum으로 추가
- 대표이미지 설정 API 추가
- 유저에서 스토어 조회시 패치 전략으로 삭제된 이미지도 가져오는 오류가 있어 filter로 처리 및 스토어 조회시엔 대표 이미지 true 인것만 노출