### PR TITLE
[BE-365] 한 메뉴에 여러 사진 등록 가능하도록 수정

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/admin/menu/AdminMenuController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/admin/menu/AdminMenuController.java
@@ -65,9 +65,10 @@ public class AdminMenuController {
     public ApiResult<AdminMenuResponse> update(
             @PathVariable long id,
 
+            @AuthenticationPrincipal UserInfo userInfo,
             @RequestBody @Valid AdminMenuUpdateRequest request
     ) {
-        adminMenuService.update(id, request);
+        adminMenuService.update(id, request, userInfo.getId());
         return ApiResult.ok();
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuController.java
@@ -63,9 +63,10 @@ public class CeoMenuController {
     public ApiResult<CeoMenuResponse> update(
             @PathVariable long id,
 
+            @AuthenticationPrincipal UserInfo userInfo,
             @RequestBody @Valid CeoMenuUpdateRequest request
     ) {
-        ceoMenuService.update(id, request);
+        ceoMenuService.update(id, request, userInfo.getId());
         return ApiResult.ok();
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/menu/AdminMenuCreateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/menu/AdminMenuCreateRequest.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
-import java.math.BigDecimal;
+import java.util.List;
 
 public record AdminMenuCreateRequest(
 
@@ -31,9 +31,9 @@ public record AdminMenuCreateRequest(
         @NotNull
         String description,
 
-        @Schema(description = "이미지 업로드 후 받은 id", example = "819f4bca-2739-46ca-9156-332c86eda619")
+        @Schema(description = "이미지 업로드 후 받은 id", example = "[\"id1\", \"id2\"]")
         @NotNull
-        String imageId,
+        List<String> imageIds,
 
         @Schema(description = "카테고리 정렬")
         @NotNull
@@ -48,14 +48,13 @@ public record AdminMenuCreateRequest(
         Boolean isRecommend
 ) {
 
-    public MenuCreateRequest toMenuCreateRequest(Store store, MenuCategory category, String imageUrl) {
+    public MenuCreateRequest toMenuCreateRequest(Store store, MenuCategory category) {
         return MenuCreateRequest.builder()
                 .store(store)
                 .category(category)
                 .name(name)
                 .price(price)
                 .description(description)
-                .imageUrl(imageUrl)
                 .sortOrder(sortOrder)
                 .isSignature(isSignature)
                 .isRecommend(isRecommend)

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/admin/menu/AdminMenuUpdateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/admin/menu/AdminMenuUpdateRequest.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
-import java.math.BigDecimal;
+import java.util.List;
 
 public record AdminMenuUpdateRequest(
 
@@ -33,7 +33,7 @@ public record AdminMenuUpdateRequest(
 
         @Schema(description = "메뉴 사진")
         @NotNull
-        String imageId,
+        List<String> imageIds,
 
         @Schema(description = "카테고리 정렬")
         @NotNull
@@ -48,7 +48,7 @@ public record AdminMenuUpdateRequest(
         Boolean isRecommend
 ) {
 
-    public MenuUpdateRequest toMenuUpdateRequest(long id, Store store, MenuCategory category, String imageUrl) {
+    public MenuUpdateRequest toMenuUpdateRequest(long id, Store store, MenuCategory category) {
         return MenuUpdateRequest.builder()
                 .store(store)
                 .id(id)
@@ -56,7 +56,6 @@ public record AdminMenuUpdateRequest(
                 .name(name)
                 .price(price)
                 .description(description)
-                .imageUrl(imageUrl)
                 .sortOrder(sortOrder)
                 .isSignature(isSignature)
                 .isRecommend(isRecommend)

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoMenuCreateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoMenuCreateRequest.java
@@ -5,9 +5,9 @@ import im.fooding.core.model.menu.MenuCategory;
 import im.fooding.core.model.store.Store;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import java.math.BigDecimal;
 
 import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
@@ -35,9 +35,9 @@ public class CeoMenuCreateRequest {
     @NotNull
     String description;
 
-    @Schema(description = "이미지 업로드 후 받은 id", example = "819f4bca-2739-46ca-9156-332c86eda619")
+    @Schema(description = "이미지 업로드 후 받은 id", example = "[\"id1\", \"id2\"]")
     @NotNull
-    String imageId;
+    List<String> imageIds;
 
     @Schema(description = "카테고리 정렬", example = "1")
     @NotNull
@@ -51,14 +51,13 @@ public class CeoMenuCreateRequest {
     @NotNull
     Boolean isRecommend;
 
-    public MenuCreateRequest toMenuCreateRequest(Store store, MenuCategory category, String imageUrl) {
+    public MenuCreateRequest toMenuCreateRequest(Store store, MenuCategory category) {
         return MenuCreateRequest.builder()
                 .store(store)
                 .category(category)
                 .name(name)
                 .price(price)
                 .description(description)
-                .imageUrl(imageUrl)
                 .sortOrder(sortOrder)
                 .isSignature(isSignature)
                 .isRecommend(isRecommend)

--- a/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoMenuUpdateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/request/ceo/menu/CeoMenuUpdateRequest.java
@@ -5,10 +5,9 @@ import im.fooding.core.model.menu.MenuCategory;
 import im.fooding.core.model.store.Store;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import java.math.BigDecimal;
 
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
@@ -36,9 +35,9 @@ public class CeoMenuUpdateRequest {
     @NotNull
     String description;
 
-    @Schema(description = "이미지 업로드 후 받은 id", example = "819f4bca-2739-46ca-9156-332c86eda619")
+    @Schema(description = "이미지 업로드 후 받은 id", example = "[\"id1\", \"id2\"]")
     @NotNull
-    String imageId;
+    List<String> imageIds;
 
     @Schema(description = "카테고리 정렬", example = "1")
     @NotNull
@@ -52,7 +51,7 @@ public class CeoMenuUpdateRequest {
     @NotNull
     Boolean isRecommend;
 
-    public MenuUpdateRequest toMenuUpdateRequest(long id, Store store, MenuCategory category, String imageUrl) {
+    public MenuUpdateRequest toMenuUpdateRequest(long id, Store store, MenuCategory category) {
         return MenuUpdateRequest.builder()
                 .store(store)
                 .id(id)
@@ -60,7 +59,6 @@ public class CeoMenuUpdateRequest {
                 .name(name)
                 .price(price)
                 .description(description)
-                .imageUrl(imageUrl)
                 .sortOrder(sortOrder)
                 .isSignature(isSignature)
                 .isRecommend(isRecommend)

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/admin/menu/AdminMenuResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/admin/menu/AdminMenuResponse.java
@@ -1,8 +1,9 @@
 package im.fooding.app.dto.response.admin.menu;
 
 import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuImage;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -27,7 +28,7 @@ public record AdminMenuResponse(
         String description,
 
         @Schema(description = "메뉴 사진")
-        String imageUrl,
+        List<String> imageUrls,
 
         @Schema(description = "카테고리 정렬")
         int sortOrder,
@@ -39,7 +40,10 @@ public record AdminMenuResponse(
         Boolean isRecommend
 ) {
 
-    public static AdminMenuResponse from(Menu menu) {
+    public static AdminMenuResponse of(Menu menu, List<MenuImage> images) {
+        List<String> imageUrls = images.stream().map(MenuImage::getImageUrl)
+                .toList();
+
         return AdminMenuResponse.builder()
                 .id(menu.getId())
                 .storeId(menu.getStore().getId())
@@ -47,7 +51,7 @@ public record AdminMenuResponse(
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .description(menu.getDescription())
-                .imageUrl(menu.getImageUrl())
+                .imageUrls(imageUrls)
                 .sortOrder(menu.getSortOrder())
                 .isSignature(menu.isSignature())
                 .isRecommend(menu.isRecommend())

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuResponse.java
@@ -3,8 +3,9 @@ package im.fooding.app.dto.response.ceo.menu;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuImage;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 
@@ -31,7 +32,7 @@ public class CeoMenuResponse {
     String description;
 
     @Schema(description = "메뉴 사진", requiredMode = REQUIRED, example = "https://d27gz6v6wvae1d.cloudfront.net/fooding/gigs/...")
-    String imageUrl;
+    List<String> imageUrls;
 
     @Schema(description = "카테고리 정렬", requiredMode = REQUIRED, example = "1")
     int sortOrder;
@@ -42,7 +43,10 @@ public class CeoMenuResponse {
     @Schema(description = "메뉴 추천 여부", requiredMode = REQUIRED, example = "true")
     Boolean isRecommend;
 
-    public static CeoMenuResponse from(Menu menu) {
+    public static CeoMenuResponse of(Menu menu, List<MenuImage> images) {
+        List<String> imageUrls = images.stream().map(MenuImage::getImageUrl)
+                .toList();
+
         return CeoMenuResponse.builder()
                 .id(menu.getId())
                 .storeId(menu.getStore().getId())
@@ -50,7 +54,7 @@ public class CeoMenuResponse {
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .description(menu.getDescription())
-                .imageUrl(menu.getImageUrl())
+                .imageUrls(imageUrls)
                 .sortOrder(menu.getSortOrder())
                 .isSignature(menu.isSignature())
                 .isRecommend(menu.isRecommend())

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/MenuResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/MenuResponse.java
@@ -1,7 +1,9 @@
 package im.fooding.app.dto.response.user.menu;
 
 import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuImage;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,8 +21,8 @@ public class MenuResponse {
     @Schema(description = "메뉴 설명", example = "매운 김치찌개")
     private String description;
 
-    @Schema(description = "메뉴 이미지 URL", example = "https://example.com/image.jpg")
-    private String imageUrl;
+    @Schema(description = "메뉴 이미지 URL", example = "['https://example.com/image.jpg', 'https://example.com/image.jpg']")
+    private List<String> imageUrls;
 
     @Schema(description = "메뉴 가격", example = "10000")
     private int price;
@@ -39,7 +41,7 @@ public class MenuResponse {
             Long id,
             String name,
             String description,
-            String imageUrl,
+            List<String> imageUrls,
             int price,
             int sortOrder,
             boolean isSignature,
@@ -48,19 +50,23 @@ public class MenuResponse {
         this.id = id;
         this.name = name;
         this.description = description;
-        this.imageUrl = imageUrl;
+        this.imageUrls = imageUrls;
         this.price = price;
         this.sortOrder = sortOrder;
         this.isSignature = isSignature;
         this.isRecommend = isRecommend;
     }
 
-    public static MenuResponse of(Menu menu) {
+    public static MenuResponse of(Menu menu, List<MenuImage> images) {
+        List<String> imageUrls = images.stream()
+                .map(MenuImage::getImageUrl)
+                .toList();
+
         return MenuResponse.builder()
                 .id(menu.getId())
                 .name(menu.getName())
                 .description(menu.getDescription())
-                .imageUrl(menu.getImageUrl())
+                .imageUrls(imageUrls)
                 .price(menu.getPrice())
                 .sortOrder(menu.getSortOrder())
                 .isSignature(menu.isSignature())

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/UserMenuResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/user/menu/UserMenuResponse.java
@@ -2,8 +2,10 @@ package im.fooding.app.dto.response.user.menu;
 
 import im.fooding.core.model.menu.Menu;
 import im.fooding.core.model.menu.MenuCategory;
+import im.fooding.core.model.menu.MenuImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,11 +34,15 @@ public class UserMenuResponse {
         this.menu = menu;
     }
 
-    public static UserMenuResponse of(MenuCategory category, List<Menu> menus) {
+    public static UserMenuResponse of(MenuCategory category, List<Menu> menus, Map<Menu, List<MenuImage>> menuImages) {
+        List<MenuResponse> menuResponses = menus.stream().map(
+                menu -> MenuResponse.of(menu, menuImages.get(menu))
+        ).toList();
+
         return UserMenuResponse.builder()
                 .id(category.getId())
                 .categoryName(category.getName())
-                .menu(menus.stream().map(MenuResponse::of).toList())
+                .menu(menuResponses)
                 .build();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/admin/menu/AdminMenuService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/admin/menu/AdminMenuService.java
@@ -13,10 +13,16 @@ import im.fooding.core.global.kafka.EventProducerService;
 import im.fooding.core.model.file.File;
 import im.fooding.core.model.menu.Menu;
 import im.fooding.core.model.menu.MenuCategory;
+import im.fooding.core.model.menu.MenuImage;
 import im.fooding.core.model.store.Store;
 import im.fooding.core.service.menu.MenuCategoryService;
+import im.fooding.core.service.menu.MenuImageService;
 import im.fooding.core.service.menu.MenuService;
 import im.fooding.core.service.store.StoreService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -28,6 +34,7 @@ import org.springframework.util.StringUtils;
 @Transactional(readOnly = true)
 public class AdminMenuService {
     private final MenuService menuService;
+    private final MenuImageService menuImageService;
     private final StoreService storeService;
     private final MenuCategoryService menuCategoryService;
     private final FileUploadService fileUploadService;
@@ -38,37 +45,60 @@ public class AdminMenuService {
         Store store = storeService.findById(request.storeId());
         MenuCategory menuCategory = menuCategoryService.get(request.categoryId());
 
-        String menuImageUrl = null;
-        if (StringUtils.hasText(request.imageId())) {
-            File file = fileUploadService.commit(request.imageId());
-            menuImageUrl = file.getUrl();
-        }
+        List<String> menuImageUrls = new ArrayList<>();
+        request.imageIds().forEach(imageId -> {
+            if (StringUtils.hasText(imageId)) {
+                File file = fileUploadService.commit(imageId);
+                menuImageUrls.add(file.getUrl());
+            }
+        });
 
-        menuService.create(request.toMenuCreateRequest(store, menuCategory, menuImageUrl));
+        long menuId = menuService.create(request.toMenuCreateRequest(store, menuCategory));
+        Menu menu = menuService.get(menuId);
+        menuImageUrls.forEach(imageUrl -> menuImageService.create(menu, imageUrl));
+
         updateStorageAveragePrice(store);
     }
 
     public AdminMenuResponse get(long id) {
-        return AdminMenuResponse.from(menuService.get(id));
+        Menu menu = menuService.get(id);
+        List<MenuImage> menuImages = menuImageService.listByMenuId(id);
+
+        return AdminMenuResponse.of(menu, menuImages);
     }
 
     public PageResponse<AdminMenuResponse> list(AdminMenuListRequest search) {
         Page<Menu> menus = menuService.list(search.getStoreId(), search.getSearchString(), search.getPageable());
-        return PageResponse.of(menus.stream().map(AdminMenuResponse::from).toList(), PageInfo.of(menus));
+        Map<Menu, List<MenuImage>> menuImages = new HashMap<>();
+
+        menus.forEach(menu -> menuImages.put(menu, menuImageService.listByMenuId(menu.getId())));
+        List<AdminMenuResponse> menuResponses = menus.stream().map(
+                menu -> AdminMenuResponse.of(menu, menuImages.get(menu))
+        ).toList();
+
+        return PageResponse.of(menuResponses, PageInfo.of(menus));
     }
 
     @Transactional
-    public void update(long id, AdminMenuUpdateRequest request) {
+    public void update(long id, AdminMenuUpdateRequest request, long updatedBy) {
         Store store = storeService.findById(request.storeId());
         MenuCategory menuCategory = menuCategoryService.get(request.categoryId());
 
-        String menuImageUrl = null;
-        if (StringUtils.hasText(request.imageId())) {
-            File file = fileUploadService.commit(request.imageId());
-            menuImageUrl = file.getUrl();
-        }
+        List<String> menuImageUrls = new ArrayList<>();
+        request.imageIds().forEach(imageId -> {
+            if (StringUtils.hasText(imageId)) {
+                File file = fileUploadService.commit(imageId);
+                menuImageUrls.add(file.getUrl());
+            }
+        });
+        Menu menu = menuService.get(id);
+        List<MenuImage> menuImages = menuImageService.listByMenuId(id);
+        menuImages.stream().filter(menuImage -> !menuImageUrls.contains(menuImage.getImageUrl()))
+                .forEach(menuImage -> menuImage.delete(updatedBy));
+        menuImageUrls.stream().filter(menuImageUrl -> !menuImages.contains(menuImageUrl))
+                .forEach(menuImageUrl -> menuImageService.create(menu, menuImageUrl));
 
-        menuService.update(request.toMenuUpdateRequest(id, store, menuCategory, menuImageUrl));
+        menuService.update(request.toMenuUpdateRequest(id, store, menuCategory));
         updateStorageAveragePrice(store);
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/menu/UserMenuService.java
@@ -3,8 +3,11 @@ package im.fooding.app.service.user.menu;
 import im.fooding.app.dto.response.user.menu.UserMenuResponse;
 import im.fooding.core.model.menu.Menu;
 import im.fooding.core.model.menu.MenuCategory;
+import im.fooding.core.model.menu.MenuImage;
 import im.fooding.core.service.menu.MenuCategoryService;
+import im.fooding.core.service.menu.MenuImageService;
 import im.fooding.core.service.menu.MenuService;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -17,6 +20,7 @@ public class UserMenuService {
 
     private final MenuService menuService;
     private final MenuCategoryService menuCategoryService;
+    private final MenuImageService menuImageService;
 
     public List<UserMenuResponse> list(Long storeId) {
         List<MenuCategory> menuCategoryList = menuCategoryService.list(storeId);
@@ -29,11 +33,19 @@ public class UserMenuService {
                 )
                 .stream()
                 .collect(Collectors.groupingBy(menu -> menu.getCategory().getId()));
+        Map<Menu, List<MenuImage>> menuImages = new HashMap<>();
+        for (List<Menu> menus : menuList.values()) {
+            for (Menu menu : menus) {
+                List<MenuImage> images = menuImageService.listByMenuId(menu.getId());
+                menuImages.put(menu, images);
+            }
+        }
 
         return menuCategoryList.stream()
                 .map(category -> UserMenuResponse.of(
                         category,
-                        menuList.getOrDefault(category.getId(), List.of())
+                        menuList.getOrDefault(category.getId(), List.of()),
+                        menuImages
                 ))
                 .toList();
     }

--- a/fooding-core/src/main/java/im/fooding/core/dto/request/menu/MenuCreateRequest.java
+++ b/fooding-core/src/main/java/im/fooding/core/dto/request/menu/MenuCreateRequest.java
@@ -2,7 +2,6 @@ package im.fooding.core.dto.request.menu;
 
 import im.fooding.core.model.menu.MenuCategory;
 import im.fooding.core.model.store.Store;
-import java.math.BigDecimal;
 import lombok.Builder;
 
 @Builder
@@ -12,7 +11,6 @@ public record MenuCreateRequest(
         String name,
         int price,
         String description,
-        String imageUrl,
         int sortOrder,
         Boolean isSignature,
         Boolean isRecommend

--- a/fooding-core/src/main/java/im/fooding/core/dto/request/menu/MenuUpdateRequest.java
+++ b/fooding-core/src/main/java/im/fooding/core/dto/request/menu/MenuUpdateRequest.java
@@ -3,6 +3,7 @@ package im.fooding.core.dto.request.menu;
 import im.fooding.core.model.menu.MenuCategory;
 import im.fooding.core.model.store.Store;
 import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -13,7 +14,7 @@ public record MenuUpdateRequest(
         String name,
         int price,
         String description,
-        String imageUrl,
+        List<String> imageUrls,
         int sortOrder,
         Boolean isSignature,
         Boolean isRecommend

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -89,7 +89,7 @@ public enum ErrorCode {
 
     // 디바이스
     DEVICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "7000", "등록된 디바이스가 없습니다."),
-    
+
     // 알림
     NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "5000", "등록된 알림이 없습니다."),
     USER_NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "5001", "사용자 알림을 찾을 수 없습니다."),
@@ -100,6 +100,7 @@ public enum ErrorCode {
     MENUCATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "6000", "등록된 메뉴 카테고리가 없습니다."),
     MENU_NOT_FOUND(HttpStatus.BAD_REQUEST, "6001", "등록된 메뉴가 없습니다."),
     MENU_BOARD_NOT_FOUND(HttpStatus.BAD_REQUEST, "6002", "등록된 메뉴판이 없습니다."),
+    MENU_IMAGE_COUNT_OVER_LIMIT(HttpStatus.BAD_REQUEST, "6003", "메뉴 이미지가 제한 개수를 넘었습니다."),
 
     // 쿠폰
     COUPON_NOT_FOUND(HttpStatus.BAD_REQUEST, "8000", "등록된 쿠폰이 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/model/menu/Menu.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/Menu.java
@@ -2,7 +2,6 @@ package im.fooding.core.model.menu;
 
 import im.fooding.core.model.BaseEntity;
 import im.fooding.core.model.store.Store;
-import im.fooding.core.model.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -13,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,9 +53,6 @@ public class Menu extends BaseEntity {
     @Column(name = "description", nullable = false)
     private String description;
 
-    @Column(name = "image_url", nullable = false)
-    private String imageUrl;
-
     @Column(name = "sort_order", nullable = false)
     private int sortOrder;
 
@@ -74,7 +69,6 @@ public class Menu extends BaseEntity {
             String name,
             int price,
             String description,
-            String imageUrl,
             int sortOrder,
             boolean isSignature,
             boolean isRecommend
@@ -84,7 +78,6 @@ public class Menu extends BaseEntity {
         this.name = name;
         this.price = price;
         this.description = description;
-        this.imageUrl = imageUrl;
         this.sortOrder = sortOrder;
         this.isSignature = isSignature;
         this.isRecommend = isRecommend;
@@ -104,10 +97,6 @@ public class Menu extends BaseEntity {
 
     public void updateDescription(String description) {
         this.description = description;
-    }
-
-    public void updateImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
     }
 
     public void updateSortOrder(int sortOrder) {

--- a/fooding-core/src/main/java/im/fooding/core/model/menu/MenuImage.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/MenuImage.java
@@ -1,0 +1,44 @@
+package im.fooding.core.model.menu;
+
+import im.fooding.core.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
+public class MenuImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "menu_id",
+            nullable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    private Menu menu;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    public MenuImage(Menu menu, String imageUrl) {
+        this.menu = menu;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuImageRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuImageRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.menu;
+
+import im.fooding.core.model.menu.MenuImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MenuImageRepository extends JpaRepository<MenuImage, Long> {
+
+    List<MenuImage> findAllByMenuId(long menuId);
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuImageService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuImageService.java
@@ -1,0 +1,39 @@
+package im.fooding.core.service.menu;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.menu.Menu;
+import im.fooding.core.model.menu.MenuImage;
+import im.fooding.core.repository.menu.MenuImageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class MenuImageService {
+
+    private final MenuImageRepository menuImageRepository;
+
+    @Transactional
+    public long create(Menu menu, String url) {
+        if (listByMenuId(menu.getId()).size() >= 3) {
+            throw new ApiException(ErrorCode.MENU_IMAGE_COUNT_OVER_LIMIT);
+        }
+
+        MenuImage menuImage = new MenuImage(menu, url);
+        menuImageRepository.save(menuImage);
+
+        return menuImage.getId();
+    }
+
+    public List<MenuImage> listByMenuId(long menuId) {
+        return menuImageRepository.findAllByMenuId(menuId).stream()
+                .filter(menuImage -> !menuImage.isDeleted())
+                .toList();
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuService.java
@@ -24,20 +24,19 @@ public class MenuService {
     private final MenuRepository menuRepository;
 
     @Transactional
-    public void create(MenuCreateRequest request) {
+    public long create(MenuCreateRequest request) {
         Menu menu = Menu.builder()
                 .store(request.store())
                 .category(request.category())
                 .name(request.name())
                 .price(request.price())
                 .description(request.description())
-                .imageUrl(request.imageUrl())
                 .sortOrder(request.sortOrder())
                 .isSignature(request.isSignature())
                 .isRecommend(request.isRecommend())
                 .build();
 
-        menuRepository.save(menu);
+        return menuRepository.save(menu).getId();
     }
 
     public Menu get(Long id) {
@@ -68,7 +67,6 @@ public class MenuService {
         menu.updateName(request.name());
         menu.updatePrice(request.price());
         menu.updateDescription(request.description());
-        menu.updateImageUrl(request.imageUrl());
         menu.updateSortOrder(request.sortOrder());
         menu.updateIsSignature(request.isSignature());
         menu.updateIsRecommend(request.isRecommend());
@@ -96,6 +94,5 @@ public class MenuService {
                 .mapToInt(Menu::getPrice)
                 .average()
                 .orElse(0);
-
     }
 }


### PR DESCRIPTION
## 이슈
- []()

## 내용
- 한 메뉴에 여러 사진 등록 가능하도록 1대 다 관계 DB 생성
- 한 메뉴당 최대 3개까지 가능하도록 처리했습니다.
- 메뉴 업데이트에서 이미지 업데이트 로직은 다음과 같습니다.
  - 기존 메뉴의 사진 리스트 불러오기
  - 기존 이미지 url의 업데이트되는 url에 포함되지 않는 이미지가 있다면 삭제
  - 기존 이미지 url에 포함되지 않는 새로운 url은 menu Image 로 새롭게 생성