### PR TITLE
[BE-372] CEO 메뉴판 API 생성

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuBoardController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuBoardController.java
@@ -1,0 +1,65 @@
+package im.fooding.app.controller.ceo.menu;
+
+import im.fooding.app.dto.response.ceo.menu.CeoMenuBoardResponse;
+import im.fooding.app.service.ceo.menu.CeoMenuBoardService;
+import im.fooding.core.common.ApiResult;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.global.UserInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ceo/stores/{storeId}/menu-boards")
+@Tag(name = "CeoMenuBoardController", description = "점주 메뉴판 컨트롤러")
+public class CeoMenuBoardController {
+
+    private final CeoMenuBoardService ceoMenuBoardService;
+
+    @PostMapping
+    @Operation(summary = "메뉴판 생성")
+    public ApiResult<Void> create(
+            @PathVariable long storeId,
+            @RequestBody @Valid CeoMenuBoardCreateRequest request
+    ) {
+        ceoMenuBoardService.create(storeId, request);
+        return ApiResult.ok();
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "메뉴판 조회")
+    public ApiResult<CeoMenuBoardResponse> get(
+            @PathVariable long id
+    ) {
+        return ApiResult.ok(ceoMenuBoardService.get(id));
+    }
+
+    @GetMapping
+    @Operation(summary = "메뉴판 조회(list)")
+    public ApiResult<PageResponse<CeoMenuBoardResponse>> list(
+            @PathVariable long storeId,
+            @Valid CeoMenuBoardListRequest request
+    ) {
+        return ApiResult.ok(ceoMenuBoardService.list(storeId, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "메뉴판 제거")
+    public ApiResult<Void> delete(
+            @AuthenticationPrincipal UserInfo userInfo,
+            @PathVariable long id
+    ) {
+        ceoMenuBoardService.delete(id, userInfo.getId());
+        return ApiResult.ok();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuBoardCreateRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuBoardCreateRequest.java
@@ -1,0 +1,14 @@
+package im.fooding.app.controller.ceo.menu;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+@Value
+public class CeoMenuBoardCreateRequest {
+
+    @Schema(description = "title", example = "제목")
+    String title;
+
+    @Schema(description = "이미지 업로드 ID", example = "e4b7f1a2-...")
+    String imageId;
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuBoardListRequest.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/menu/CeoMenuBoardListRequest.java
@@ -1,0 +1,6 @@
+package im.fooding.app.controller.ceo.menu;
+
+import im.fooding.core.common.BasicSearch;
+
+public class CeoMenuBoardListRequest extends BasicSearch {
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuBoardResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuBoardResponse.java
@@ -1,0 +1,34 @@
+package im.fooding.app.dto.response.ceo.menu;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import im.fooding.core.model.menu.MenuBoard;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class CeoMenuBoardResponse {
+
+    @Schema(description = "ID", requiredMode = REQUIRED, example = "1")
+    long id;
+
+    @Schema(description = "가게 ID", requiredMode = REQUIRED, example = "1")
+    long storeId;
+
+    @Schema(description = "제목", requiredMode = NOT_REQUIRED, example = "제목")
+    String title;
+
+    @Schema(description = "이미지 업로드 ID", requiredMode = REQUIRED, example = "https://example.com/image.jpg")
+    String imageUrl;
+
+    public static CeoMenuBoardResponse from(MenuBoard menuBoard) {
+        return CeoMenuBoardResponse.builder()
+                .id(menuBoard.getId())
+                .storeId(menuBoard.getStore().getId())
+                .imageUrl(menuBoard.getImageUrl())
+                .build();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/ceo/menu/CeoMenuBoardService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/ceo/menu/CeoMenuBoardService.java
@@ -1,0 +1,64 @@
+package im.fooding.app.service.ceo.menu;
+
+import im.fooding.app.controller.ceo.menu.CeoMenuBoardCreateRequest;
+import im.fooding.app.controller.ceo.menu.CeoMenuBoardListRequest;
+import im.fooding.app.dto.response.ceo.menu.CeoMenuBoardResponse;
+import im.fooding.app.service.file.FileUploadService;
+import im.fooding.core.common.PageInfo;
+import im.fooding.core.common.PageResponse;
+import im.fooding.core.dto.request.menu.MenuBoardCreateRequest;
+import im.fooding.core.model.file.File;
+import im.fooding.core.model.menu.MenuBoard;
+import im.fooding.core.model.store.Store;
+import im.fooding.core.service.menu.MenuBoardService;
+import im.fooding.core.service.store.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CeoMenuBoardService {
+
+    private final MenuBoardService menuBoardService;
+    private final StoreService storeService;
+    private final FileUploadService fileUploadService;
+
+    @Transactional
+    public void create(long storeId, CeoMenuBoardCreateRequest request) {
+        Store store = storeService.findById(storeId);
+
+        String imageUrl = null;
+        if (StringUtils.hasText(request.getImageId())) {
+            File file = fileUploadService.commit(request.getImageId());
+            imageUrl = file.getUrl();
+        }
+
+        MenuBoardCreateRequest menuBoardCreateRequest = MenuBoardCreateRequest.builder()
+                .title(request.getTitle())
+                .store(store)
+                .imageUrl(imageUrl)
+                .build();
+
+        menuBoardService.create(menuBoardCreateRequest);
+    }
+
+    public CeoMenuBoardResponse get(long id) {
+        return CeoMenuBoardResponse.from(menuBoardService.get(id));
+    }
+
+    public PageResponse<CeoMenuBoardResponse> list(long storeId, CeoMenuBoardListRequest request) {
+        Page<MenuBoard> menuBoards = menuBoardService.listByStoreId(storeId, request.getPageable());
+        Page<CeoMenuBoardResponse> responses = menuBoards.map(CeoMenuBoardResponse::from);
+
+        return PageResponse.of(responses.toList(), PageInfo.of(responses));
+    }
+
+    @Transactional
+    public void delete(long id, Long userId) {
+        menuBoardService.delete(id, userId);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -101,6 +101,7 @@ public enum ErrorCode {
     MENU_NOT_FOUND(HttpStatus.BAD_REQUEST, "6001", "등록된 메뉴가 없습니다."),
     MENU_BOARD_NOT_FOUND(HttpStatus.BAD_REQUEST, "6002", "등록된 메뉴판이 없습니다."),
     MENU_IMAGE_COUNT_OVER_LIMIT(HttpStatus.BAD_REQUEST, "6003", "메뉴 이미지가 제한 개수를 넘었습니다."),
+    MENU_BOARD_COUNT_OVER_LIMIT(HttpStatus.BAD_REQUEST, "6004", "메뉴판이 제한 개수를 넘었습니다."),
 
     // 쿠폰
     COUPON_NOT_FOUND(HttpStatus.BAD_REQUEST, "8000", "등록된 쿠폰이 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuBoardRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/MenuBoardRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MenuBoardRepository extends JpaRepository<MenuBoard, Long> {
+public interface MenuBoardRepository extends JpaRepository<MenuBoard, Long>, QMenuBoardRepository {
 
     Page<MenuBoard> findAllByDeletedFalse(Pageable pageable);
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuBoardRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuBoardRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.menu;
+
+import im.fooding.core.model.menu.MenuBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QMenuBoardRepository {
+
+    Page<MenuBoard> listByStoreId(long storeId, Pageable pageable);
+
+    long countByStoreId(long storeId);
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuBoardRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/menu/QMenuBoardRepositoryImpl.java
@@ -1,0 +1,61 @@
+package im.fooding.core.repository.menu;
+
+import static im.fooding.core.model.menu.QMenuBoard.menuBoard;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.model.menu.MenuBoard;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class QMenuBoardRepositoryImpl implements QMenuBoardRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MenuBoard> listByStoreId(long storeId, Pageable pageable) {
+        var where = menuBoard.deleted.isFalse();
+        where = where.and(menuBoard.store.id.eq(storeId));
+
+        return getMenuBoards(where, pageable);
+    }
+
+    @Override
+    public long countByStoreId(long storeId) {
+        var where = menuBoard.deleted.isFalse();
+        where = where.and(menuBoard.store.id.eq(storeId));
+
+        return countMenuBoards(where);
+    }
+
+    public long countMenuBoards(BooleanExpression where) {
+        Long total = queryFactory
+                .select(menuBoard.count())
+                .from(menuBoard)
+                .where(where)
+                .fetchOne();
+
+        if (total == null) {
+            return 0L;
+        }
+        return total;
+    }
+
+    private PageImpl<MenuBoard> getMenuBoards(BooleanExpression where, Pageable pageable) {
+        List<MenuBoard> results = queryFactory
+                .selectFrom(menuBoard)
+                .where(where)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(menuBoard.id.asc())
+                .fetch();
+
+        long total = countMenuBoards(where);
+
+        return new PageImpl<>(results, pageable, total);
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuBoardService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuBoardService.java
@@ -16,10 +16,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MenuBoardService {
 
+    static final long MAX_MENU_BOARD_PER_STORE = 8L;
+
     private final MenuBoardRepository menuBoardRepository;
 
     @Transactional
     public void create(MenuBoardCreateRequest request) {
+        if (menuBoardRepository.countByStoreId(request.getStore().getId()) > MAX_MENU_BOARD_PER_STORE) {
+            throw new ApiException(ErrorCode.MENU_BOARD_COUNT_OVER_LIMIT);
+        }
+
         MenuBoard menuBoard = MenuBoard.builder()
                 .store(request.getStore())
                 .title(request.getTitle())
@@ -37,6 +43,10 @@ public class MenuBoardService {
 
     public Page<MenuBoard> list(Pageable pageable) {
         return menuBoardRepository.findAllByDeletedFalse(pageable);
+    }
+
+    public Page<MenuBoard> listByStoreId(long storeId, Pageable pageable) {
+        return menuBoardRepository.listByStoreId(storeId, pageable);
     }
 
     @Transactional


### PR DESCRIPTION
## 이슈
- [[CEO] 메뉴판 API 생성](https://www.notion.so/benkang/CEO-API-27783feabad3808a8dbdfd99d801505f?source=copy_link)

## 내용
- Create AP 생성
- Read AP 생성
- Read(list) AP 생성
- Delete AP 생성
- 메뉴판 모델 가게당 개수 제한 추가 (8개)