### PR TITLE
[BE-283] 리워드 사용 알림 로직 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -157,13 +157,13 @@ public class UserNotificationApplicationService {
 
     @KafkaEventHandler(RewardUseEvent.class)
     public void sendRewardUseMessage(RewardUseEvent event) {
-        RewardPoint rewardPoint = rewardService.get(event.rewardId());
+        NotificationTemplate template = notificationTemplateService.getByType(Type.RewardUseSms);
 
+        RewardPoint rewardPoint = rewardService.get(event.rewardId());
         String storeName = rewardPoint.getStore().getName();
 
-        // 리워드 사용 템플릿
-        String subject = "푸딩 리워드 사용 완료";
-        String content = "[푸딩]\n%s에 %d 포인트가 사용되었어요.\n잔여 포인트 : %d".formatted(
+        String subject = template.getSubject();
+        String content = template.getContent().formatted(
                 storeName,
                 event.usePoint(),
                 event.remainPoint()

--- a/fooding-core/src/main/java/im/fooding/core/event/reward/RewardUseEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/reward/RewardUseEvent.java
@@ -1,0 +1,8 @@
+package im.fooding.core.event.reward;
+
+public record RewardUseEvent(
+        long rewardId,
+        int usePoint,
+        int remainPoint
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
@@ -26,7 +26,8 @@ public class NotificationTemplate extends BaseDocument {
     public enum Type {
         WaitingCreatedEmail,
         WaitingCreatedSms,
-        RewardEarnSms
+        RewardEarnSms,
+        RewardUseSms
     }
 
     public NotificationTemplate(Type type, String subject, String content) {

--- a/fooding-core/src/main/java/im/fooding/core/service/reward/RewardService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/reward/RewardService.java
@@ -19,6 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class RewardService {
     private final RewardPointRepository repository;
 
+    public RewardPoint get(long id) {
+        return repository.findById(id)
+                .filter(it -> !it.isDeleted())
+                .orElseThrow(() -> new ApiException(ErrorCode.REWARD_NOT_FOUND));
+    }
+
     /**
      * 리워드 조회
      *


### PR DESCRIPTION
## 이슈
- [리워드 사용 이벤트를 카프카로 핸들링해서 메시지 보내도록 수정](https://www.notion.so/benkang/24c83feabad3800899fbc16b4f7d82b5?source=copy_link)

## 내용
- 리우드 사용 알림 로직 추가
  - Kafka 이벤트 방식으로 로직 추가
  - 알림 템플릿 방식 적용

## 메모
- 리워드 사용 알림 템플릿 json
  ```json
  {
    "type": "RewardUseSms",
    "subject": "푸딩 리워드 사용 완료",
    "content": "[푸딩]\n%s에 %d 포인트가 사용되었어요.\n잔여 포인트 : %d"
  }
  ```