### PR TITLE
[BE-337] [BE-338] 아이디/비밀번호 찾기 기능 구현

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/auth/CeoAuthController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/auth/CeoAuthController.java
@@ -1,0 +1,40 @@
+package im.fooding.app.controller.ceo.auth;
+
+import im.fooding.app.service.auth.AuthService;
+import im.fooding.core.common.ApiResult;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@Slf4j
+@RequestMapping( "/api/v1/ceo/auth")
+@RequiredArgsConstructor
+public class CeoAuthController {
+    private final AuthService authService;
+
+    @GetMapping( "/find/email" )
+    public ApiResult<Map<String, String>> findEmail(
+            @RequestParam String name,
+            @RequestParam String phoneNumber
+    ){
+        String email = authService.findUserEmail( name, phoneNumber);
+        return ApiResult.ok( Map.of( "email", email ) );
+    }
+
+    @GetMapping( "/find/password" )
+    public ApiResult<Void> findPassword(
+            @RequestParam String email,
+            @RequestParam String name,
+            @RequestParam String phoneNumber
+    ){
+        authService.findUserPassword( email, name, phoneNumber);
+        return ApiResult.ok();
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/auth/CeoAuthController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/auth/CeoAuthController.java
@@ -1,14 +1,14 @@
 package im.fooding.app.controller.ceo.auth;
 
+import im.fooding.app.dto.response.ceo.auth.CeoAuthenticatePhoneResponse;
 import im.fooding.app.service.auth.AuthService;
 import im.fooding.core.common.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -16,26 +16,73 @@ import java.util.Map;
 @Slf4j
 @RequestMapping( "/api/v1/ceo/auth")
 @RequiredArgsConstructor
+@Tag( name = "CeoAuthControlelr", description = "CEO 인증 및 계정 관련 컨트롤러" )
 public class CeoAuthController {
     private final AuthService authService;
 
-    // 이메일( 아이디 ) 찾기 API
-    @GetMapping( "/find/email" )
-    public ApiResult<Map<String, String>> findEmail(
+    // 휴대폰 인증
+    @PostMapping( "/verify/phone" )
+    @Operation(summary = "휴대폰 인증 진행", description = "휴대폰으로 6자리의 int타입 인증 코드를 전송한다.")
+    public ApiResult<Void> sendAuthenticationCode(
             @RequestParam String name,
             @RequestParam String phoneNumber
     ){
-        String email = authService.findUserEmail( name, phoneNumber);
-        return ApiResult.ok( Map.of( "email", email ) );
+        authService.sendAuthenticateCode( name, phoneNumber );
+        return ApiResult.ok();
     }
 
-    // 비밀번호 찾기 API
-    @GetMapping( "/find/password" )
-    public ApiResult<Void> findPassword(
-            @RequestParam String name,
-            @RequestParam String phoneNumber
+    // 인증번호 확인
+    @GetMapping( "/verify/phone" )
+    @Operation(summary = "휴대폰 인증 확인", description = "SMS로 받은 6자리 int 타입의 인증 코드가 올바른지 확인한다.")
+    public ApiResult<CeoAuthenticatePhoneResponse> checkAuthenticationCode(
+            @RequestParam String phoneNumber,
+            @RequestParam int code
     ){
-        authService.findUserPassword( name, phoneNumber);
+        return ApiResult.ok( authService.isCorrectCode( phoneNumber, code ) );
+    }
+
+    // 이메일(아이디) 찾기 결과 전달
+    @GetMapping( "/find/email" )
+    @Operation(summary = "아이디 찾기 결과 전달", description = "사용자의 이메일(아이디) 찾기 조회 결과를 전달한다.")
+    public ApiResult<Map<String, String>> findEmail(
+            @RequestParam String phoneNumber,
+            @RequestParam int code
+    ){
+        return ApiResult.ok( Map.of( "email", authService.getEmail( phoneNumber, code ) ) );
+    }
+
+    // 이메일을 통한 재설정 링크 전달
+    @Operation(summary = "이메일을 통한 비밀번호 재설정 주소 전달", description = "사용자의 이메일로 비밀번호 재설정 링크를 전달한다.")
+    @GetMapping( "/find/password/email" )
+    public ApiResult<Void> getLinkByEmail(
+            @RequestParam String name,
+            @RequestParam String phoneNumber,
+            @RequestParam int code
+    ){
+        authService.sendPasswordResetUrl( name, phoneNumber, code, true );
+        return ApiResult.ok();
+    }
+
+    // SMS를 통한 재설정 링크 전달
+    @GetMapping( "/find/password/sms" )
+    @Operation(summary = "SMS를 통한 비밀번호 재설정 주소 전달", description = "사용자의 SMS로 비밀번호 재설정 링크를 전달한다.")
+    public ApiResult<Void> getLinkBySms(
+            @RequestParam String name,
+            @RequestParam String phoneNumber,
+            @RequestParam int code
+    ){
+        authService.sendPasswordResetUrl( name, phoneNumber, code, false );
+        return ApiResult.ok();
+    }
+
+    // 비밀번호 재설정
+    @PostMapping( "/reset/password/{encodedLine}" )
+    @Operation(summary = "비밀번호 변경", description = "인코딩 된 정보를 토대로 비밀번호를 변경한다.")
+    public ApiResult<Void> resetPassword(
+            @PathVariable String encodedLine,
+            @RequestParam String password
+    ){
+        authService.resetPassword( encodedLine, password );
         return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/controller/ceo/auth/CeoAuthController.java
+++ b/fooding-api/src/main/java/im/fooding/app/controller/ceo/auth/CeoAuthController.java
@@ -19,6 +19,7 @@ import java.util.Map;
 public class CeoAuthController {
     private final AuthService authService;
 
+    // 이메일( 아이디 ) 찾기 API
     @GetMapping( "/find/email" )
     public ApiResult<Map<String, String>> findEmail(
             @RequestParam String name,
@@ -28,13 +29,13 @@ public class CeoAuthController {
         return ApiResult.ok( Map.of( "email", email ) );
     }
 
+    // 비밀번호 찾기 API
     @GetMapping( "/find/password" )
     public ApiResult<Void> findPassword(
-            @RequestParam String email,
             @RequestParam String name,
             @RequestParam String phoneNumber
     ){
-        authService.findUserPassword( email, name, phoneNumber);
+        authService.findUserPassword( name, phoneNumber);
         return ApiResult.ok();
     }
 }

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/auth/CeoAuthenticatePhoneResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/auth/CeoAuthenticatePhoneResponse.java
@@ -1,0 +1,23 @@
+package im.fooding.app.dto.response.ceo.auth;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CeoAuthenticatePhoneResponse {
+    private boolean isSuccess;
+    private String email;
+    private String phoneNumber;
+    private int code;
+
+    @Builder
+    public CeoAuthenticatePhoneResponse(
+            boolean isSuccess, String email, String phoneNumber, int code
+    ){
+        this.isSuccess = isSuccess;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.code = code;
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/service/auth/AuthService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/auth/AuthService.java
@@ -337,4 +337,48 @@ public class AuthService {
         user.updatedRefreshToken(tokenResponse.getRefreshToken());
         return tokenResponse;
     }
+
+    /**
+     * 아이디 찾기
+     *
+     * @param name
+     * @param phoneNumber
+     * @return String
+     */
+    public String findUserEmail( String name, String phoneNumber ){
+
+        return null;
+    }
+
+    /**
+     * 비밀번호 찾기
+     * @param email
+     * @param name
+     * @param phoneNumber
+     */
+    public void findUserPassword( String email, String name, String phoneNumber ){
+        // 해당 사용자가 있는지 확인
+
+        // 해당 사용자가 있는 경우 본인 인증 진행
+
+        // 임시 비밀번호 생성
+        
+        // 임시 비밀번호 이메일로 전달
+        
+        // 임시 비밀번호 전달 여부 공지
+    }
+
+    /**
+     * 본인 인증
+     * @param email
+     * @param phoneNumber
+     * @return boolean
+     */
+    public boolean certifyUser( String email, String phoneNumber ){
+        // 이메일 인증의 경우
+
+        // 전화번호 인증의 경우 --> Pass 인증 등
+
+        return false;
+    }
 }

--- a/fooding-api/src/main/java/im/fooding/app/service/auth/AuthService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/auth/AuthService.java
@@ -346,8 +346,8 @@ public class AuthService {
      * @return String
      */
     public String findUserEmail( String name, String phoneNumber ){
-
-        return null;
+        String email = this.userService.findEmailByPhoneNumberAndName( phoneNumber, name );
+        return email;
     }
 
     /**
@@ -374,7 +374,7 @@ public class AuthService {
      * @param phoneNumber
      * @return boolean
      */
-    public boolean certifyUser( String email, String phoneNumber ){
+    private boolean certifyUser( String email, String phoneNumber ){
         // 이메일 인증의 경우
 
         // 전화번호 인증의 경우 --> Pass 인증 등

--- a/fooding-api/src/main/resources/application-local.yml
+++ b/fooding-api/src/main/resources/application-local.yml
@@ -96,10 +96,10 @@ webhook:
 
 email:
   smtp:
-    host: smtp.gmail.com
-    port: 587
-  username: foodinghelper@fooding.im
-  password: kzptuibhpdhlgpnb
+    host: ${SMTP_HOST}
+    port: ${SMPT_PORT}
+  username: ${SMTP_USERNAME}
+  password: ${SMTP_PASSWORD}
 
 message:
   sender: 02-1234-5678

--- a/fooding-api/src/main/resources/application-local.yml
+++ b/fooding-api/src/main/resources/application-local.yml
@@ -94,6 +94,13 @@ webhook:
   slack:
     url: ${WEBHOOK_SLACK_URL:}
 
+email:
+  smtp:
+    host: smtp.gmail.com
+    port: 587
+  username: foodinghelper@fooding.im
+  password: kzptuibhpdhlgpnb
+
 message:
   sender: 02-1234-5678
 

--- a/fooding-core/build.gradle.kts
+++ b/fooding-core/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
     //slack
     implementation("com.slack.api:slack-api-client:1.29.2")
 
+    // Google SMTP
+    implementation("org.springframework.boot:spring-boot-starter-mail")
+
     //feign
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.3"))
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")

--- a/fooding-core/src/main/java/im/fooding/core/event/auth/AuthFindEventListener.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/auth/AuthFindEventListener.java
@@ -1,6 +1,7 @@
 package im.fooding.core.event.auth;
 
 import im.fooding.core.global.infra.slack.SlackClient;
+import im.fooding.core.global.infra.smtp.GoogleSMTP;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AuthFindEventListener {
     private final SlackClient slackClient;
+    private final GoogleSMTP googleSMTP;
 
     // 휴대폰 6자리 코드 인증
     @EventListener
@@ -39,4 +41,8 @@ public class AuthFindEventListener {
     }
     
     // 이메일로 비밀번호 재설정 링크 전달
+    @EventListener
+    public void handleSendUrlByEmailEvent( AuthGetResetUrlByEmailEvent event ){
+        googleSMTP.sendEmail( event.email(), event.resetUrl() );
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/event/auth/AuthFindEventListener.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/auth/AuthFindEventListener.java
@@ -1,0 +1,42 @@
+package im.fooding.core.event.auth;
+
+import im.fooding.core.global.infra.slack.SlackClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthFindEventListener {
+    private final SlackClient slackClient;
+
+    // 휴대폰 6자리 코드 인증
+    @EventListener
+    public void handlePhoneAuthenticateEvent( AuthPhoneAuthenticateEvent event ){
+        String slackMessage = String.format(
+                "[본인 인증 안내]\n \"%s\"님, 본인인증 코드입니다. \n[ %s ]\n\n---\n\n발송 정보\n - 채널: %s\n - 번호: %s",
+                event.name(),
+                event.code(),
+                event.channel(),
+                event.phoneNumber()
+        );
+        slackClient.sendNotificationMessage(slackMessage);
+    }
+    
+    // 휴대폰으로 비밀번호 재설정 링크 전달
+    @EventListener
+    public void handleSendUrlByPhoneEvent( AuthGetResetUrlByPhoneEvent event ){
+        String slackMessage = String.format(
+                "[비밀번호 재설정 안내]\n \"%s\"님, 비밀번호 재설정을 위한 주소입니다.. \n %s \n\n---\n\n발송 정보\n - 채널: %s\n - 번호: %s",
+                event.name(),
+                event.resetUrl(),
+                event.channel(),
+                event.phoneNumber()
+        );
+        slackClient.sendNotificationMessage(slackMessage);
+    }
+    
+    // 이메일로 비밀번호 재설정 링크 전달
+}

--- a/fooding-core/src/main/java/im/fooding/core/event/auth/AuthGetResetUrlByEmailEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/auth/AuthGetResetUrlByEmailEvent.java
@@ -1,0 +1,12 @@
+package im.fooding.core.event.auth;
+
+import im.fooding.core.model.notification.NotificationChannel;
+
+public record AuthGetResetUrlByEmailEvent(
+        String name,
+        String email,
+        String resetUrl,
+        String senderEmail,
+        NotificationChannel channel
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/event/auth/AuthGetResetUrlByPhoneEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/auth/AuthGetResetUrlByPhoneEvent.java
@@ -1,0 +1,12 @@
+package im.fooding.core.event.auth;
+
+import im.fooding.core.model.notification.NotificationChannel;
+
+public record AuthGetResetUrlByPhoneEvent(
+        String name,
+        String phoneNumber,
+        String resetUrl,
+        String senderNumber,
+        NotificationChannel channel
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/event/auth/AuthPhoneAuthenticateEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/auth/AuthPhoneAuthenticateEvent.java
@@ -1,0 +1,12 @@
+package im.fooding.core.event.auth;
+
+import im.fooding.core.model.notification.NotificationChannel;
+
+public record AuthPhoneAuthenticateEvent(
+        String name,
+        int code,
+        String senderNumber,
+        String phoneNumber,
+        NotificationChannel channel
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     SOCIAL_LOGIN_ONLY(HttpStatus.BAD_REQUEST, "1007", "유저는 소셜로그인으로만 가입 가능합니다."),
     NICKNAME_GENERATE_FAILED(HttpStatus.BAD_REQUEST, "1008", "닉네임 자동 생성에 실패하셨습니다."),
     LOGIN_PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "1009", "비밀번호가 틀렸습니다."),
+    AUTHENTICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "1010", "존재하지 않는 인증입니다."),
 
     // 가게
     STORE_NOT_FOUND(HttpStatus.BAD_REQUEST, "2000", "등록된 가게 정보가 없습니다."),

--- a/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTP.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTP.java
@@ -2,6 +2,7 @@ package im.fooding.core.global.infra.smtp;
 
 
 import jakarta.mail.*;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import java.util.Properties;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class GoogleSMTP {
     @Value("${email.smtp.host}")
     private String SMTP_HOST;
@@ -20,13 +22,13 @@ public class GoogleSMTP {
     @Value("${email.password}")
     private String PASSWORD;
 
-    private GoogleSMTPTemplate  smtpTemplate;
+    private final GoogleSMTPTemplate  smtpTemplate;
 
     public boolean sendEmail( String targetEmail, String url){
         try{
             Properties props = new Properties();
             props.put( "mail.smtp.host", SMTP_HOST );
-            props.put( "mail.smtp.post", SMTP_PORT );
+            props.put( "mail.smtp.port", SMTP_PORT );
             props.put( "mail.smtp.auth", "true" );
             props.put( "mail.smtp.starttls.enable", "true" );
             props.put( "mail.smtp.ssl.trust", SMTP_HOST );

--- a/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTP.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTP.java
@@ -1,9 +1,12 @@
 package im.fooding.core.global.infra.smtp;
 
 
+import jakarta.mail.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.Properties;
 
 @Service
 @Slf4j
@@ -17,8 +20,31 @@ public class GoogleSMTP {
     @Value("${email.password}")
     private String PASSWORD;
 
-    public static boolean sendEmail( String targetEmail, GoogleSMTPTemplate template ){
+    private GoogleSMTPTemplate  smtpTemplate;
 
-        return true;
+    public boolean sendEmail( String targetEmail, String url){
+        try{
+            Properties props = new Properties();
+            props.put( "mail.smtp.host", SMTP_HOST );
+            props.put( "mail.smtp.post", SMTP_PORT );
+            props.put( "mail.smtp.auth", "true" );
+            props.put( "mail.smtp.starttls.enable", "true" );
+            props.put( "mail.smtp.ssl.trust", SMTP_HOST );
+
+            Authenticator auth = new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication( USERNAME, PASSWORD );
+                }
+            };
+            Session session = Session.getInstance( props, auth );
+            Message message = smtpTemplate.createMessage( session, USERNAME, targetEmail, "[Fooding] 비밀번호 재설정", url );
+            Transport.send( message );
+            return true;
+        }
+        catch( Exception e ){
+            System.out.println( e.getMessage() );
+        }
+        return false;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTP.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTP.java
@@ -1,0 +1,24 @@
+package im.fooding.core.global.infra.smtp;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class GoogleSMTP {
+    @Value("${email.smtp.host}")
+    private String SMTP_HOST;
+    @Value("${email.smtp.port}")
+    private String SMTP_PORT;
+    @Value("${email.username}")
+    private String USERNAME;
+    @Value("${email.password}")
+    private String PASSWORD;
+
+    public static boolean sendEmail( String targetEmail, GoogleSMTPTemplate template ){
+
+        return true;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTPTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTPTemplate.java
@@ -1,0 +1,5 @@
+package im.fooding.core.global.infra.smtp;
+
+public class GoogleSMTPTemplate {
+
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTPTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTPTemplate.java
@@ -1,5 +1,56 @@
 package im.fooding.core.global.infra.smtp;
 
+import jakarta.mail.Message;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
 public class GoogleSMTPTemplate {
 
+    public Message createMessage(Session session, String sender, String receiver, String title, String url ){
+        try{
+            Message message = new MimeMessage( session );
+
+            message.setFrom( new InternetAddress( sender, title ) );
+            message.setRecipients( Message.RecipientType.TO, InternetAddress.parse( receiver ) );
+            message.setSubject( "비밀번호 재설정 주소입니다." );
+
+            // HTML 형식 본문 전달
+            message.setContent( htmlContent(url), "text/html; charset=UTF-8" );
+            return message;
+        }
+        catch( Exception e ){
+            System.out.println( e.getMessage() );
+            return null;
+        }
+    }
+
+    private String htmlContent( String url ){
+        return """
+            <html>
+            <body style='font-family: Arial, sans-serif; margin: 0; padding: 20px;'>
+                <div style='max-width: 600px; margin: 0 auto; border: 1px solid #ddd; border-radius: 10px; padding: 30px;'>
+                    <h2 style='color: #333; text-align: center;'> 비밀번호 재설정 </h2>
+                    <p style='color: #666; font-size: 16px; line-height: 1.5;'>
+                        안녕하세요.<br>
+                        비밀번호 재설정을 위한 URL을 전달드립니다.
+                    </p>
+                    <div style='background-color: #f8f9fa; padding: 20px; border-radius: 5px; text-align: center; margin: 20px 0;'>
+                        <h1 style='color: #007bff; font-size: 32px; margin: 0; letter-spacing: 5px;'>
+                            %s
+                        </h1>
+                    </div>
+                    <p style='color: #666; font-size: 14px;'>
+                        • 인증번호는 <strong>20분간</strong> 유효합니다.<br>
+                        • 본인이 요청하지 않은 정보라면 고객센터에 문의해주시기 바랍니다.
+                    </p>
+                    <hr style='border: none; border-top: 1px solid #eee; margin: 20px 0;'>
+                    <p style='color: #999; font-size: 12px; text-align: center;'>
+                        본 메일은 발신전용입니다.
+                    </p>
+                </div>
+            </body>
+            </html>
+            """.formatted(url);
+    }
 }

--- a/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTPTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/infra/smtp/GoogleSMTPTemplate.java
@@ -4,7 +4,9 @@ import jakarta.mail.Message;
 import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+import org.springframework.stereotype.Component;
 
+@Component
 public class GoogleSMTPTemplate {
 
     public Message createMessage(Session session, String sender, String receiver, String title, String url ){
@@ -36,9 +38,9 @@ public class GoogleSMTPTemplate {
                         비밀번호 재설정을 위한 URL을 전달드립니다.
                     </p>
                     <div style='background-color: #f8f9fa; padding: 20px; border-radius: 5px; text-align: center; margin: 20px 0;'>
-                        <h1 style='color: #007bff; font-size: 32px; margin: 0; letter-spacing: 5px;'>
-                            %s
-                        </h1>
+                        <a style='color: #007bff; font-size: 20px; margin: 0; letter-spacing: 5px;'>
+                            https://fooding.im/%s
+                        </a>
                     </div>
                     <p style='color: #666; font-size: 14px;'>
                         • 인증번호는 <strong>20분간</strong> 유효합니다.<br>

--- a/fooding-core/src/main/java/im/fooding/core/model/user/Authentication.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/user/Authentication.java
@@ -21,6 +21,9 @@ public class Authentication {
     private String email;
 
     @Column( nullable = false )
+    private String phoneNumber;
+
+    @Column( nullable = false )
     private int code;
 
     @Column( nullable = false )
@@ -33,9 +36,10 @@ public class Authentication {
     private boolean isSuccess;
 
     @Builder
-    public Authentication( String email, int code ){
+    public Authentication( String email, String phoneNumber, int code ){
         this.email = email;
         this.code = code;
+        this.phoneNumber = phoneNumber;
         this.requestedAt = LocalDateTime.now();
         this.expiredAt = LocalDateTime.now().plusMinutes( 20 );     // 현재 제한 시간을 20분으로 제한
         this.isSuccess = false;

--- a/fooding-core/src/main/java/im/fooding/core/model/user/Authentication.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/user/Authentication.java
@@ -1,0 +1,45 @@
+package im.fooding.core.model.user;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table( name = "authentication" )
+public class Authentication {
+    @Id
+    @GeneratedValue( strategy = GenerationType.IDENTITY )
+    private long id;
+
+    @Column( nullable = false )
+    private String email;
+
+    @Column( nullable = false )
+    private int code;
+
+    @Column( nullable = false )
+    private LocalDateTime requestedAt;
+
+    @Column( nullable = false )
+    private LocalDateTime expiredAt;
+
+    @Column( nullable = false )
+    private boolean isSuccess;
+
+    @Builder
+    public Authentication( String email, int code ){
+        this.email = email;
+        this.code = code;
+        this.requestedAt = LocalDateTime.now();
+        this.expiredAt = LocalDateTime.now().plusMinutes( 20 );     // 현재 제한 시간을 20분으로 제한
+        this.isSuccess = false;
+    }
+
+    public void success(){ this.isSuccess = true; }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/user/AuthenticationRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/user/AuthenticationRepository.java
@@ -1,0 +1,12 @@
+package im.fooding.core.repository.user;
+
+import im.fooding.core.model.user.Authentication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AuthenticationRepository extends JpaRepository<Authentication, Long> {
+    Optional<Authentication> findByPhoneNumberAndCodeAndIsSuccessFalse( String phoneNumber, int code );
+    List<Authentication> findAllByEmailAndPhoneNumber( String email, String phoneNumber );
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/user/AuthenticationRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/user/AuthenticationRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface AuthenticationRepository extends JpaRepository<Authentication, Long> {
-    Optional<Authentication> findByPhoneNumberAndCodeAndIsSuccessFalse( String phoneNumber, int code );
-    List<Authentication> findAllByEmailAndPhoneNumber( String email, String phoneNumber );
+public interface AuthenticationRepository extends JpaRepository<Authentication, Long>, QAuthenticationRepository {
+
 }

--- a/fooding-core/src/main/java/im/fooding/core/repository/user/QAuthenticationRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/user/QAuthenticationRepository.java
@@ -1,0 +1,9 @@
+package im.fooding.core.repository.user;
+
+import im.fooding.core.model.user.Authentication;
+
+import java.util.List;
+
+public interface QAuthenticationRepository {
+    List<Authentication> list( String email, String phoneNumber, int code, boolean isSuccess );
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/user/QAuthenticationRepositoryImpl.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/user/QAuthenticationRepositoryImpl.java
@@ -1,0 +1,37 @@
+package im.fooding.core.repository.user;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import im.fooding.core.model.user.Authentication;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static im.fooding.core.model.user.QAuthentication.authentication;
+
+@RequiredArgsConstructor
+public class QAuthenticationRepositoryImpl implements QAuthenticationRepository{
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<Authentication> list(
+            String email,
+            String phoneNumber,
+            int code,
+            boolean isSuccess)
+    {
+        BooleanBuilder condition = new BooleanBuilder();
+        if( isSuccess ) condition.and( authentication.isSuccess.isTrue() );
+        else condition.and( authentication.isSuccess.isFalse() );
+        if( email != null ) condition.and( authentication.email.eq( email ) );
+        if( phoneNumber != null ) condition.and( authentication.phoneNumber.eq( phoneNumber ) );
+        if( code != 0 ) condition.and( authentication.code.eq( code ) );
+
+        return query.
+                select( authentication )
+                .from( authentication )
+                .where( condition )
+                .fetch();
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/repository/user/UserRepository.java
+++ b/fooding-core/src/main/java/im/fooding/core/repository/user/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long>, QUserReposito
     @Override
     @EntityGraph(attributePaths = {"authorities"})
     Optional<User> findById(Long id);
+
+    Optional<User> findByPhoneNumberAndName(String phoneNumber, String name);
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/user/AuthenticationService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/user/AuthenticationService.java
@@ -1,0 +1,46 @@
+package im.fooding.core.service.user;
+
+import im.fooding.core.global.exception.ApiException;
+import im.fooding.core.global.exception.ErrorCode;
+import im.fooding.core.model.user.Authentication;
+import im.fooding.core.repository.user.AuthenticationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticationService {
+    private final AuthenticationRepository repository;
+
+    public void create( String email, String phoneNumber, int code ){
+        // 진행되지 않은 인증 or 만료되지 않은 인증 모두 삭제
+        List<Authentication> expiredAuthentications = repository.findAllByEmailAndPhoneNumber( email, phoneNumber );
+        expiredAuthentications.forEach(Authentication::success);
+        // 새로운 인증 생성
+        Authentication authentication = Authentication.builder()
+                .email( email )
+                .code( code )
+                .build();
+        repository.save( authentication );
+    }
+
+    @Transactional
+    public boolean checkCodeAvailable( String phoneNumber, int code ){
+        // 인증 정보 확인
+        Authentication authentication = repository.findByPhoneNumberAndCodeAndIsSuccessFalse( phoneNumber, code ).orElseThrow(
+                () -> new ApiException(ErrorCode.AUTHENTICATION_NOT_FOUND, "인증 정보가 올바르지 않습니다." )
+        );
+        // 만료 시간 확인
+        if( authentication.getExpiredAt().isBefore(LocalDateTime.now() ) ) return false;
+        // 인증 정보 확인 완료 표시
+        authentication.success();
+
+        return true;
+    }
+}

--- a/fooding-core/src/main/java/im/fooding/core/service/user/UserService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/user/UserService.java
@@ -214,4 +214,17 @@ public class UserService {
         return userRepository.findByPhoneNumber(phoneNumber)
                 .filter(it -> !it.isDeleted());
     }
+
+    /**
+     * 이름 + 전화번호로 이메일 조회
+     *
+     * @param phoneNumber
+     * @param name
+     */
+    public String findEmailByPhoneNumberAndName( String phoneNumber, String name) {
+        User user = userRepository.findByPhoneNumberAndName( phoneNumber, name ).orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+        // Role에 따른 로직이 필요할 경우 구현
+
+        return user.getEmail();
+    }
 }


### PR DESCRIPTION
**<구현 API>**

1. 휴대폰으로 인증번호 전달 -> 현재 Slack으로 구현 ( 실제 SMS 사용은 유료 서비스 )
2. 인증번호 확인
3. 찾은 사용자의 이메일(아이디) 전달
4. 이메일로 비밀번호 재설정 링크 전달
5. SMS로 비밀번호 재설정 링크 전달 -> 현재 Slack으로 구현

* 아이디 찾기, 비밀번호 찾기 Flow와 각 과정에서 사용하는 API, 그리고 FE에서 해주어야 하는 작업에 대해서는 아래 Notion에서 자세히 설명해두었습니다. 참고 바랍니다.
*
[이이디/비밀번호 찾기](**url**)
