### PR TITLE
[BE-376] 메뉴 이미지에 ID 추가

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuImageResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuImageResponse.java
@@ -1,0 +1,21 @@
+package im.fooding.app.dto.response.ceo.menu;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+@Value
+public class CeoMenuImageResponse {
+
+    @Schema(description = "메뉴 이미지 ID", requiredMode = REQUIRED, example = "819f4bca-2739-46ca-9156-332c86eda619")
+    String id;
+
+    @Schema(description = "메뉴 이미지 URL", requiredMode = REQUIRED, example = "https://d27gz6v6wvae1d.cloudfront.net/fooding/gigs/...")
+    String url;
+
+    public CeoMenuImageResponse(String id, String url) {
+        this.id = id;
+        this.url = url;
+    }
+}

--- a/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuResponse.java
+++ b/fooding-api/src/main/java/im/fooding/app/dto/response/ceo/menu/CeoMenuResponse.java
@@ -31,8 +31,8 @@ public class CeoMenuResponse {
     @Schema(description = "메뉴 설명", requiredMode = REQUIRED, example = "맛있는 초밥")
     String description;
 
-    @Schema(description = "메뉴 사진", requiredMode = REQUIRED, example = "https://d27gz6v6wvae1d.cloudfront.net/fooding/gigs/...")
-    List<String> imageUrls;
+    @Schema(description = "메뉴 사진", requiredMode = REQUIRED)
+    List<CeoMenuImageResponse> images;
 
     @Schema(description = "카테고리 정렬", requiredMode = REQUIRED, example = "1")
     int sortOrder;
@@ -44,7 +44,8 @@ public class CeoMenuResponse {
     Boolean isRecommend;
 
     public static CeoMenuResponse of(Menu menu, List<MenuImage> images) {
-        List<String> imageUrls = images.stream().map(MenuImage::getImageUrl)
+        List<CeoMenuImageResponse> imageResponses = images.stream()
+                .map(menuImage -> new CeoMenuImageResponse(menuImage.getImageId(), menuImage.getImageUrl()))
                 .toList();
 
         return CeoMenuResponse.builder()
@@ -54,7 +55,7 @@ public class CeoMenuResponse {
                 .name(menu.getName())
                 .price(menu.getPrice())
                 .description(menu.getDescription())
-                .imageUrls(imageUrls)
+                .images(imageResponses)
                 .sortOrder(menu.getSortOrder())
                 .isSignature(menu.isSignature())
                 .isRecommend(menu.isRecommend())

--- a/fooding-core/src/main/java/im/fooding/core/model/menu/MenuImage.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/menu/MenuImage.java
@@ -34,11 +34,15 @@ public class MenuImage extends BaseEntity {
     )
     private Menu menu;
 
+    @Column(name = "image_id", nullable = false)
+    private String imageId;
+
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
-    public MenuImage(Menu menu, String imageUrl) {
+    public MenuImage(Menu menu, String imageId, String imageUrl) {
         this.menu = menu;
+        this.imageId = imageId;
         this.imageUrl = imageUrl;
     }
 }

--- a/fooding-core/src/main/java/im/fooding/core/service/menu/MenuImageService.java
+++ b/fooding-core/src/main/java/im/fooding/core/service/menu/MenuImageService.java
@@ -20,12 +20,12 @@ public class MenuImageService {
     private final MenuImageRepository menuImageRepository;
 
     @Transactional
-    public long create(Menu menu, String url) {
+    public long create(Menu menu, String imageId, String url) {
         if (listByMenuId(menu.getId()).size() >= 3) {
             throw new ApiException(ErrorCode.MENU_IMAGE_COUNT_OVER_LIMIT);
         }
 
-        MenuImage menuImage = new MenuImage(menu, url);
+        MenuImage menuImage = new MenuImage(menu, imageId, url);
         menuImageRepository.save(menuImage);
 
         return menuImage.getId();


### PR DESCRIPTION
## 이슈
- [메뉴 이미지 도메인 ID 추가](https://www.notion.so/benkang/ID-27e83feabad3802ea1f3f4817dd97f62?source=copy_link)

## 내용
- 수정시 메뉴 이미지 ID로 이루어지기 때문에 메뉴 이미지 ID를 함께 반환해야 함.
- 메뉴 이미지 ID도 함께 반환하기 위해 도메인에 ID 추가 및 함께 반환

## 메뉴
- 영향이 가는 코드 함께 수정
- USER에서는 수정이 이루어지지 않는다고 판단하여 url만 반환하는 기존 코드 유지