### PR TITLE
[BE-377] 웨이팅 입장 알림 이벤트, 템플릿 방식으로 전환

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/service/pos/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/pos/waiting/PosWaitingService.java
@@ -9,6 +9,7 @@ import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
 import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.event.waiting.StoreWaitingCallEvent;
 import im.fooding.core.event.waiting.StoreWaitingRegisteredEvent;
 import im.fooding.core.global.kafka.EventProducerService;
 import im.fooding.core.model.store.Store;
@@ -88,12 +89,9 @@ public class PosWaitingService {
     public void call(long storeWaitingId) {
         StoreWaiting storeWaiting = storeWaitingService.call(storeWaitingId);
 
-        WaitingSetting waitingSetting = waitingSettingService.getActiveSetting(storeWaiting.getStore());
-
-        userNotificationApplicationService.sendWaitingCallMessage(
-                storeWaiting.getStoreName(),
-                storeWaiting.getCallNumber(),
-                waitingSetting.getEntryTimeLimitMinutes()
+        eventProducerService.publishEvent(
+                StoreWaitingCallEvent.class.getSimpleName(),
+                new StoreWaitingCallEvent(storeWaitingId)
         );
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/service/pos/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/pos/waiting/PosWaitingService.java
@@ -87,7 +87,7 @@ public class PosWaitingService {
 
     @Transactional
     public void call(long storeWaitingId) {
-        StoreWaiting storeWaiting = storeWaitingService.call(storeWaitingId);
+        storeWaitingService.call(storeWaitingId);
 
         eventProducerService.publishEvent(
                 StoreWaitingCallEvent.class.getSimpleName(),

--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -109,11 +109,17 @@ public class UserNotificationApplicationService {
         StoreWaiting storeWaiting = storeWaitingService.get(event.storeWaitingId());
         WaitingSetting waitingSetting = waitingSettingService.getActiveSetting(storeWaiting.getStore());
 
-        String message = WaitingMessageBuilder.buildWaitingCallMessage(
-                storeWaiting.getStoreName(),
+        NotificationTemplate template = notificationTemplateService.getByType(Type.WaitingCallSms);
+
+        String subject = template.getSubject();
+        String content = template.getContent().formatted(
                 storeWaiting.getCallNumber(),
+                storeWaiting.getStoreName(),
                 waitingSetting.getEntryTimeLimitMinutes()
         );
+
+        String message = WaitingMessageBuilder.buildMessage(subject, content);
+
         slackClient.sendNotificationMessage(message);
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -3,6 +3,7 @@ package im.fooding.app.service.user.notification;
 import im.fooding.app.dto.response.user.notification.UserNotificationResponse;
 import im.fooding.core.event.reward.RewardEarnEvent;
 import im.fooding.core.event.reward.RewardUseEvent;
+import im.fooding.core.event.waiting.StoreWaitingCallEvent;
 import im.fooding.core.event.waiting.StoreWaitingRegisteredEvent;
 import im.fooding.core.global.infra.slack.SlackClient;
 import im.fooding.core.global.kafka.KafkaEventHandler;
@@ -13,11 +14,13 @@ import im.fooding.core.model.notification.NotificationTemplate.Type;
 import im.fooding.core.model.notification.UserNotification;
 import im.fooding.core.model.reward.RewardPoint;
 import im.fooding.core.model.waiting.StoreWaiting;
+import im.fooding.core.model.waiting.WaitingSetting;
 import im.fooding.core.model.waiting.WaitingUser;
 import im.fooding.core.service.notification.NotificationTemplateService;
 import im.fooding.core.service.notification.UserNotificationService;
 import im.fooding.core.service.reward.RewardService;
 import im.fooding.core.service.waiting.StoreWaitingService;
+import im.fooding.core.service.waiting.WaitingSettingService;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +42,7 @@ public class UserNotificationApplicationService {
     private final UserNotificationService userNotificationService;
     private final NotificationTemplateService notificationTemplateService;
     private final StoreWaitingService storeWaitingService;
+    private final WaitingSettingService waitingSettingService;
     private final RewardService rewardService;
 
     @Value("${message.sender}")
@@ -100,8 +104,16 @@ public class UserNotificationApplicationService {
                 });
     }
 
-    public void sendWaitingCallMessage(String store, int callNumber, int entryTimeLimit) {
-        String message = WaitingMessageBuilder.buildWaitingCallMessage(store, callNumber, entryTimeLimit);
+    @KafkaEventHandler(StoreWaitingCallEvent.class)
+    public void sendWaitingCallMessage(StoreWaitingCallEvent event) {
+        StoreWaiting storeWaiting = storeWaitingService.get(event.storeWaitingId());
+        WaitingSetting waitingSetting = waitingSettingService.getActiveSetting(storeWaiting.getStore());
+
+        String message = WaitingMessageBuilder.buildWaitingCallMessage(
+                storeWaiting.getStoreName(),
+                storeWaiting.getCallNumber(),
+                waitingSetting.getEntryTimeLimitMinutes()
+        );
         slackClient.sendNotificationMessage(message);
     }
 

--- a/fooding-core/src/main/java/im/fooding/core/event/waiting/StoreWaitingCallEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/waiting/StoreWaitingCallEvent.java
@@ -1,0 +1,6 @@
+package im.fooding.core.event.waiting;
+
+public record StoreWaitingCallEvent(
+        long storeWaitingId
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/global/util/WaitingMessageBuilder.java
+++ b/fooding-core/src/main/java/im/fooding/core/global/util/WaitingMessageBuilder.java
@@ -2,21 +2,6 @@ package im.fooding.core.global.util;
 
 public class WaitingMessageBuilder {
 
-    public static String buildWaitingCallMessage(String store, int callNumber, int entryTimeLimit) {
-        return """
-                Title
-                입장할 순서예요! 지금 매장에 입장해 주세요!
-                                
-                %d번 고객님, 기다려주셔서 감사해요!
-                %s에 입장해 주세요:)
-                                
-                직원에게 톡 사진을 보여주시면 순서대로 안내드릴게요!
-                                
-                %d분으로 입장 시간이 제한되어있어요. 방문이 취소될 수 있으니 시간 확인 부탁드려요!
-                """
-                .formatted(callNumber, store, entryTimeLimit);
-    }
-
     public static String buildEnterStoreMessage(String sender, String receiver, String store, String notice, int waitingNumber, int limitTime) {
         StringBuilder messageBuilder = new StringBuilder();
 

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
@@ -26,6 +26,7 @@ public class NotificationTemplate extends BaseDocument {
     public enum Type {
         WaitingCreatedEmail,
         WaitingCreatedSms,
+        WaitingCallSms,
         RewardEarnSms,
         RewardUseSms
     }


### PR DESCRIPTION
## 이슈
- [웨이팅 입장 알림 이벤트, 템플릿 방식으로 전환](https://www.notion.so/benkang/27f83feabad38091a807d62d508b2cb6?source=copy_link)

## 내용
- 웨이팅 입장 알림 이벤트 방식으로 전환
- 웨이팅 입장 알림 템플릿 방식으로 전환

## 메모
- 웨이팅 입장 템플릿
  ```json
  {
    "type": "WaitingCallSms",
    "subject": "입장할 순서예요! 지금 매장에 입장해 주세요!",
    "content": "%d번 고객님, 기다려주셔서 감사해요!\n%s에 입장해 주세요:)\n\n직원에게 톡 사진을 보여주시면 순서대로 안내드릴게요!\n\n%d분으로 입장 시간이 제한되어있어요. 방문이 취소될 수 있으니 시간 확인 부탁드려요!"
  }
  ```