### PR TITLE
Be 378

### DIFF
--- a/fooding-api/src/main/java/im/fooding/app/service/pos/waiting/PosWaitingService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/pos/waiting/PosWaitingService.java
@@ -9,6 +9,7 @@ import im.fooding.core.common.PageInfo;
 import im.fooding.core.common.PageResponse;
 import im.fooding.core.dto.request.waiting.StoreWaitingFilter;
 import im.fooding.core.dto.request.waiting.WaitingUserRegisterRequest;
+import im.fooding.core.event.waiting.StoreWaitingCanceledEvent;
 import im.fooding.core.event.waiting.StoreWaitingRegisteredEvent;
 import im.fooding.core.global.kafka.EventProducerService;
 import im.fooding.core.model.store.Store;
@@ -80,8 +81,12 @@ public class PosWaitingService {
 
     @Transactional
     public void cancel(long storeWaitingId, String reason) {
-        StoreWaiting canceledWaiting = storeWaitingService.cancel(storeWaitingId);
-        userNotificationApplicationService.sendWaitingCancelMessage(canceledWaiting.getStoreName(), reason);
+        storeWaitingService.cancel(storeWaitingId);
+
+        eventProducerService.publishEvent(
+                StoreWaitingCanceledEvent.class.getSimpleName(),
+                new StoreWaitingCanceledEvent(storeWaitingId, reason)
+        );
     }
 
     @Transactional

--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -3,6 +3,7 @@ package im.fooding.app.service.user.notification;
 import im.fooding.app.dto.response.user.notification.UserNotificationResponse;
 import im.fooding.core.event.reward.RewardEarnEvent;
 import im.fooding.core.event.reward.RewardUseEvent;
+import im.fooding.core.event.waiting.StoreWaitingCanceledEvent;
 import im.fooding.core.event.waiting.StoreWaitingRegisteredEvent;
 import im.fooding.core.global.infra.slack.SlackClient;
 import im.fooding.core.global.kafka.KafkaEventHandler;
@@ -120,8 +121,14 @@ public class UserNotificationApplicationService {
         slackClient.sendNotificationMessage(message);
     }
 
-    public void sendWaitingCancelMessage(String store, String reason) {
-        String message = WaitingMessageBuilder.buildCancel(store, reason);
+    @KafkaEventHandler(StoreWaitingCanceledEvent.class)
+    public void sendWaitingCancelMessage(StoreWaitingCanceledEvent event) {
+        String storeName = storeWaitingService.get(event.storeWaitingId())
+                .getStoreName();
+        String message = WaitingMessageBuilder.buildCancel(
+                storeName,
+                event.reason()
+        );
         slackClient.sendNotificationMessage(message);
     }
 

--- a/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
+++ b/fooding-api/src/main/java/im/fooding/app/service/user/notification/UserNotificationApplicationService.java
@@ -123,12 +123,17 @@ public class UserNotificationApplicationService {
 
     @KafkaEventHandler(StoreWaitingCanceledEvent.class)
     public void sendWaitingCancelMessage(StoreWaitingCanceledEvent event) {
+        NotificationTemplate template = notificationTemplateService.getByType(Type.WaitingCancelSms);
+
         String storeName = storeWaitingService.get(event.storeWaitingId())
                 .getStoreName();
-        String message = WaitingMessageBuilder.buildCancel(
+
+        String subject = template.getSubject();
+        String content = template.getContent().formatted(
                 storeName,
                 event.reason()
         );
+        String message = WaitingMessageBuilder.buildMessage(subject, content);
         slackClient.sendNotificationMessage(message);
     }
 

--- a/fooding-core/src/main/java/im/fooding/core/event/waiting/StoreWaitingCanceledEvent.java
+++ b/fooding-core/src/main/java/im/fooding/core/event/waiting/StoreWaitingCanceledEvent.java
@@ -1,0 +1,7 @@
+package im.fooding.core.event.waiting;
+
+public record StoreWaitingCanceledEvent(
+        long storeWaitingId,
+        String reason
+) {
+}

--- a/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
+++ b/fooding-core/src/main/java/im/fooding/core/model/notification/NotificationTemplate.java
@@ -26,6 +26,7 @@ public class NotificationTemplate extends BaseDocument {
     public enum Type {
         WaitingCreatedEmail,
         WaitingCreatedSms,
+        WaitingCancelSms,
         RewardEarnSms,
         RewardUseSms
     }


### PR DESCRIPTION
## 이슈
- [웨이팅 취소 알림 이벤트, 템플릿 방식으로 전환](https://www.notion.so/benkang/27f83feabad380d7a289f0f86ffade91?source=copy_link)

## 내용
- 웨이팅 취소 알림 이벤트 방식으로 전환
- 웨이팅 취소 알림 템플릿 방식으로 전환

## 메모
- 웨이팅 취소 템플릿
  ```json
  {
    "type": "WaitingCancelSms",
    "subject": "웨이팅이 취소되었습니다.",
    "content": "[%s]의 웨이팅이 취소되었어요.\n\n사유: %s\n\n다음에 방문해 주세요!"
  }
  ```